### PR TITLE
투표 상세 결과뷰 색상 변경 및 기기별 탭바 숨기도록 변경

### DIFF
--- a/Picme/Picme.xcodeproj/project.pbxproj
+++ b/Picme/Picme.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		A9E72E2F26C52F62003C98A0 /* YPImagePicker in Frameworks */ = {isa = PBXBuildFile; productRef = A9E72E2E26C52F62003C98A0 /* YPImagePicker */; };
 		D1103F6226C46AE4002D1E78 /* Enum+NetworkResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1103F6126C46AE4002D1E78 /* Enum+NetworkResult.swift */; };
 		D1103F6426C46B44002D1E78 /* MainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1103F6326C46B44002D1E78 /* MainService.swift */; };
+		D1206D462711E4FA00D5B199 /* Extension+UIDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1206D452711E4FA00D5B199 /* Extension+UIDevice.swift */; };
 		D12B119A26CD057B00777498 /* Extension+UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12B119926CD057B00777498 /* Extension+UIViewController.swift */; };
 		D12B119C26CD924200777498 /* LoginUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D12B119B26CD924200777498 /* LoginUser.swift */; };
 		D138B3F926E2F25000323A0B /* DateHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D138B3F826E2F25000323A0B /* DateHelper.swift */; };
@@ -201,6 +202,7 @@
 		CE1E7EEC4130AD59C5A0B524 /* Pods-Picme.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Picme.release.xcconfig"; path = "Target Support Files/Pods-Picme/Pods-Picme.release.xcconfig"; sourceTree = "<group>"; };
 		D1103F6126C46AE4002D1E78 /* Enum+NetworkResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Enum+NetworkResult.swift"; sourceTree = "<group>"; };
 		D1103F6326C46B44002D1E78 /* MainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainService.swift; sourceTree = "<group>"; };
+		D1206D452711E4FA00D5B199 /* Extension+UIDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+UIDevice.swift"; sourceTree = "<group>"; };
 		D12B119926CD057B00777498 /* Extension+UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Extension+UIViewController.swift"; sourceTree = "<group>"; };
 		D12B119B26CD924200777498 /* LoginUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUser.swift; sourceTree = "<group>"; };
 		D138B3F826E2F25000323A0B /* DateHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateHelper.swift; sourceTree = "<group>"; };
@@ -555,6 +557,7 @@
 				D12B119926CD057B00777498 /* Extension+UIViewController.swift */,
 				D1F7E2CA26E11091002E95F4 /* Extension+UIButton.swift */,
 				D1F7E2CE26E12192002E95F4 /* Extension+UIImage.swift */,
+				D1206D452711E4FA00D5B199 /* Extension+UIDevice.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1152,6 +1155,7 @@
 				D180456A26B3E2940053430E /* MainCollectionViewCell.swift in Sources */,
 				A9322EEB26BFD81A0061EF35 /* Extension+UIAlert.swift in Sources */,
 				A9322EF026C099990061EF35 /* StepView.swift in Sources */,
+				D1206D462711E4FA00D5B199 /* Extension+UIDevice.swift in Sources */,
 				A91A904626B92BDB00C43D43 /* OnboardingUserInfo.swift in Sources */,
 				D1B51CA426BEB72400928FF3 /* VoteDetailService.swift in Sources */,
 				D180456C26B3E8DD0053430E /* APIConstants.swift in Sources */,

--- a/Picme/Picme/Model/MyPage/MyPageModel.swift
+++ b/Picme/Picme/Model/MyPage/MyPageModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct MyPageModel: Codable {
     let createdCount: Int
-    let attendedCount : Int
+    let attendedCount: Int
     
     enum CodingKeys: String, CodingKey {
         case createdCount = "numOfCreatedPosts"

--- a/Picme/Picme/Utility/Extension/Extension+UIDevice.swift
+++ b/Picme/Picme/Utility/Extension/Extension+UIDevice.swift
@@ -1,0 +1,130 @@
+//
+//  Extension+UIDevice.swift
+//  Picme
+//
+//  Created by 권민하 on 2021/10/09.
+//
+
+import StoreKit
+
+public enum Model : String {
+    
+    //Simulator
+    case simulator     = "simulator/sandbox",
+         
+         //iPhone
+         iPhone4            = "iPhone 4",
+         iPhone4S           = "iPhone 4S",
+         iPhone5            = "iPhone 5",
+         iPhone5S           = "iPhone 5S",
+         iPhone5C           = "iPhone 5C",
+         iPhone6            = "iPhone 6",
+         iPhone6Plus        = "iPhone 6 Plus",
+         iPhone6S           = "iPhone 6S",
+         iPhone6SPlus       = "iPhone 6S Plus",
+         iPhoneSE           = "iPhone SE",
+         iPhone7            = "iPhone 7",
+         iPhone7Plus        = "iPhone 7 Plus",
+         iPhone8            = "iPhone 8",
+         iPhone8Plus        = "iPhone 8 Plus",
+         iPhoneX            = "iPhone X",
+         iPhoneXS           = "iPhone XS",
+         iPhoneXSMax        = "iPhone XS Max",
+         iPhoneXR           = "iPhone XR",
+         iPhone11           = "iPhone 11",
+         iPhone11Pro        = "iPhone 11 Pro",
+         iPhone11ProMax     = "iPhone 11 Pro Max",
+         iPhoneSE2          = "iPhone SE 2nd gen",
+         iPhone12Mini       = "iPhone 12 Mini",
+         iPhone12           = "iPhone 12",
+         iPhone12Pro        = "iPhone 12 Pro",
+         iPhone12ProMax     = "iPhone 12 Pro Max",
+         iPhone13Mini       = "iPhone 13 Mini",
+         iPhone13           = "iPhone 13",
+         iPhone13Pro        = "iPhone 13 Pro",
+         iPhone13ProMax     = "iPhone 13 Pro Max",
+         
+         unrecognized       = "?unrecognized?"
+}
+
+// #-#-#-#-#-#-#-#-#-#-#-#-#
+// MARK: UIDevice extensions
+// #-#-#-#-#-#-#-#-#-#-#-#-#
+
+public extension UIDevice {
+    
+    var type: Model {
+        var systemInfo = utsname()
+        uname(&systemInfo)
+        let modelCode = withUnsafePointer(to: &systemInfo.machine) {
+            $0.withMemoryRebound(to: CChar.self, capacity: 1) {
+                ptr in String.init(validatingUTF8: ptr)
+            }
+        }
+        
+        let modelMap : [String: Model] = [
+            
+            //Simulator
+            "i386"      : .simulator,
+            "x86_64"    : .simulator,
+            "arm64"     : .simulator,
+            
+            //iPhone
+            "iPhone3,1" : .iPhone4,
+            "iPhone3,2" : .iPhone4,
+            "iPhone3,3" : .iPhone4,
+            "iPhone4,1" : .iPhone4S,
+            "iPhone5,1" : .iPhone5,
+            "iPhone5,2" : .iPhone5,
+            "iPhone5,3" : .iPhone5C,
+            "iPhone5,4" : .iPhone5C,
+            "iPhone6,1" : .iPhone5S,
+            "iPhone6,2" : .iPhone5S,
+            "iPhone7,1" : .iPhone6Plus,
+            "iPhone7,2" : .iPhone6,
+            "iPhone8,1" : .iPhone6S,
+            "iPhone8,2" : .iPhone6SPlus,
+            "iPhone8,4" : .iPhoneSE,
+            "iPhone9,1" : .iPhone7,
+            "iPhone9,3" : .iPhone7,
+            "iPhone9,2" : .iPhone7Plus,
+            "iPhone9,4" : .iPhone7Plus,
+            "iPhone10,1" : .iPhone8,
+            "iPhone10,4" : .iPhone8,
+            "iPhone10,2" : .iPhone8Plus,
+            "iPhone10,5" : .iPhone8Plus,
+            "iPhone10,3" : .iPhoneX,
+            "iPhone10,6" : .iPhoneX,
+            "iPhone11,2" : .iPhoneXS,
+            "iPhone11,4" : .iPhoneXSMax,
+            "iPhone11,6" : .iPhoneXSMax,
+            "iPhone11,8" : .iPhoneXR,
+            "iPhone12,1" : .iPhone11,
+            "iPhone12,3" : .iPhone11Pro,
+            "iPhone12,5" : .iPhone11ProMax,
+            "iPhone12,8" : .iPhoneSE2,
+            "iPhone13,1" : .iPhone12Mini,
+            "iPhone13,2" : .iPhone12,
+            "iPhone13,3" : .iPhone12Pro,
+            "iPhone13,4" : .iPhone12ProMax,
+            "iPhone14,4" : .iPhone13Mini,
+            "iPhone14,5" : .iPhone13,
+            "iPhone14,2" : .iPhone13Pro,
+            "iPhone14,3" : .iPhone13ProMax,
+        ]
+        
+        guard let mcode = modelCode, let map = String(validatingUTF8: mcode), let model = modelMap[map] else {
+            return Model.unrecognized
+        }
+        
+        if model == .simulator {
+            if let simModelCode = ProcessInfo().environment["SIMULATOR_MODEL_IDENTIFIER"] {
+                if let simMap = String(validatingUTF8: simModelCode), let simModel = modelMap[simMap] {
+                    return simModel
+                }
+            }
+        }
+        
+        return model
+    }
+}

--- a/Picme/Picme/Utility/Extension/Extension+UITableView.swift
+++ b/Picme/Picme/Utility/Extension/Extension+UITableView.swift
@@ -21,8 +21,7 @@ extension UITableView {
         return cell
     }
     
-    
-    func scrollToTop(isAnimated:Bool = true) {
+    func scrollToTop(isAnimated: Bool = true) {
 
         DispatchQueue.main.async {
             let indexPath = IndexPath(row: 0, section: 0)

--- a/Picme/Picme/View/Controller/Main/MainViewController.swift
+++ b/Picme/Picme/View/Controller/Main/MainViewController.swift
@@ -137,14 +137,15 @@ extension MainViewController: MainViewModelDelegate {
     func onFetchCompleted(with newIndexPathsToReload: [IndexPath]?) {
         // 첫 로딩 - 1페이지일 경우
         guard let newIndexPathsToReload = newIndexPathsToReload else {
+            
+            ActivityView.instance.stop()
+            
             // 처음 1페이지일 때 아무것도 없으면 empty view
             if viewModel.mainList.isEmpty {
                 self.showEmptyView()
             }
             
             mainTableView.reloadData()
-            
-            ActivityView.instance.stop()
             
             return
         }

--- a/Picme/Picme/View/Controller/Main/MainViewController.swift
+++ b/Picme/Picme/View/Controller/Main/MainViewController.swift
@@ -53,10 +53,6 @@ class MainViewController: BaseViewContoller, UITableViewDelegate {
         self.initRefresh()
         
         viewModel = MainViewModel(service: MainService(), delegate: self)
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
         
         ActivityView.instance.start(controller: self)
         
@@ -64,8 +60,19 @@ class MainViewController: BaseViewContoller, UITableViewDelegate {
         viewModel.currentPage = 1
         viewModel.mainList = []
         viewModel.fetchMainList()
-        
     }
+    
+//    override func viewWillAppear(_ animated: Bool) {
+//        super.viewWillAppear(animated)
+//
+//        ActivityView.instance.start(controller: self)
+//
+//        viewModel.page = 0
+//        viewModel.currentPage = 1
+//        viewModel.mainList = []
+//        viewModel.fetchMainList()
+//
+//    }
     
     // MARK: - Empty View
     

--- a/Picme/Picme/View/Controller/Main/MainViewController.swift
+++ b/Picme/Picme/View/Controller/Main/MainViewController.swift
@@ -62,17 +62,19 @@ class MainViewController: BaseViewContoller, UITableViewDelegate {
         viewModel.fetchMainList()
     }
     
-//    override func viewWillAppear(_ animated: Bool) {
-//        super.viewWillAppear(animated)
-//
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        self.tabBarController?.tabBar.isHidden = false
+
 //        ActivityView.instance.start(controller: self)
 //
 //        viewModel.page = 0
 //        viewModel.currentPage = 1
 //        viewModel.mainList = []
 //        viewModel.fetchMainList()
-//
-//    }
+
+    }
     
     // MARK: - Empty View
     

--- a/Picme/Picme/View/Controller/Main/MainViewController.swift
+++ b/Picme/Picme/View/Controller/Main/MainViewController.swift
@@ -54,26 +54,23 @@ class MainViewController: BaseViewContoller, UITableViewDelegate {
         
         viewModel = MainViewModel(service: MainService(), delegate: self)
         
-        ActivityView.instance.start(controller: self)
-        
-        viewModel.page = 0
-        viewModel.currentPage = 1
-        viewModel.mainList = []
-        viewModel.fetchMainList()
+        initViewModel()
     }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         self.tabBarController?.tabBar.isHidden = false
-
-//        ActivityView.instance.start(controller: self)
-//
-//        viewModel.page = 0
-//        viewModel.currentPage = 1
-//        viewModel.mainList = []
-//        viewModel.fetchMainList()
-
+    }
+    
+    func initViewModel() {
+        ActivityView.instance.start(controller: self)
+        
+        viewModel.page = 0
+        viewModel.currentPage = 1
+        viewModel.mainList = []
+        
+        viewModel.fetchMainList()
     }
     
     // MARK: - Empty View

--- a/Picme/Picme/View/Controller/MyPage/MyPageViewController.swift
+++ b/Picme/Picme/View/Controller/MyPage/MyPageViewController.swift
@@ -72,11 +72,8 @@ final class MyPageViewController: BaseViewContoller {
     // MARK: - Button Actions
     
     func setupButtons() {
-         allVoteListButton.tag = 1
          allVoteListButton.addTarget(self, action: #selector(showAlertView), for: UIControl.Event.touchUpInside)
-
-        // settingButton.tag = 3
-        // settingButton.addTarget(self, action: #selector(showAlertView), for: UIControl.Event.touchUpInside)
+        settingButton.addTarget(self, action: #selector(showAlertView), for: UIControl.Event.touchUpInside)
     }
     
     @objc func showAlertView(_ sender: UIButton) {
@@ -99,10 +96,6 @@ final class MyPageViewController: BaseViewContoller {
 
 extension MyPageViewController: AlertViewActionDelegate {
     
-    func serviceTapped() {
-        
-    }
-    
     func logOutTapped() {
         guard let userVendor = loginUserInfo.vendor else { return }
         self.viewModel.logOutAction(from: userVendor)
@@ -120,8 +113,4 @@ extension MyPageViewController: LogOutProtocol {
         loginVC.modalPresentationStyle = .fullScreen
         self.present(loginVC, animated: true, completion: nil)
     }
-}
-
-extension MyPageViewController {
-    
 }

--- a/Picme/Picme/View/Controller/MyPage/SettingViewController.swift
+++ b/Picme/Picme/View/Controller/MyPage/SettingViewController.swift
@@ -90,7 +90,7 @@ class SettingViewController: UIViewController {
     
 }
 
-//extension UITextField {
+// extension UITextField {
 //
 //    // Clear Button White
 //    open override func layoutSubviews() {
@@ -103,18 +103,18 @@ class SettingViewController: UIViewController {
 //              }
 //          }
 //      }
-//}
+// }
 
-//// MARK: - addPadding
+////  MARK: - addPadding
 //
-//extension UITextField {
+// extension UITextField {
 //
 //    func addRightPadding() {
 //        let paddingView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: self.frame.height))
 //        self.rightView = paddingView
 //        self.rightViewMode = ViewMode.always
 //    }
-//}
+// }
 
 extension SettingViewController: UITextFieldDelegate {
     

--- a/Picme/Picme/View/Controller/VoteCreate/VoteComplete/ContentViewController.swift
+++ b/Picme/Picme/View/Controller/VoteCreate/VoteComplete/ContentViewController.swift
@@ -84,6 +84,7 @@ final class ContentViewController: BaseViewContoller {
                            let mainVC = mainNav.topViewController as? MainViewController {
                             
                             mainVC.mainTableView.scrollToTop()
+                            mainVC.initViewModel()
                             Toast.show(using: .voteUpload, controller: mainVC)
                         }
                     }

--- a/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
+++ b/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
@@ -115,13 +115,24 @@ class VoteDetailViewController: BaseViewContoller {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        print("* token : \(APIConstants.jwtToken)")
-        
         setConfiguration()
         setupButton()
         createTimer()
         
         bindViewModel()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        let deviceType = UIDevice().type
+        
+        print("* Running on: \(deviceType)")
+        
+        switch deviceType {
+        case .iPhone6, .iPhone7, .iPhone8, .iPhoneSE, .iPhoneSE2: self.tabBarController?.tabBar.isHidden = true
+        default: break
+        }
     }
     
     // MARK: - Bind View Model
@@ -237,19 +248,19 @@ extension CarouselDatasource: UICollectionViewDataSource {
                 
                 // 1위 이미지일 경우
                 /*
-                if firstRankSet.contains(indexPath.row) {
-                    // 작성자 원픽이 1위 or 투표자 투표 이미지가 1위일 경우
-                    if (isSameNickname && object.onePickImageId == indexPath.row) || (loginUserNickname != object.postNickname && object.votedImageId == indexPath.row) {
-                        cell.resultColorView.backgroundColor = #colorLiteral(red: 0.9215686275, green: 0.2862745098, blue: 0.6039215686, alpha: 0.8)
-                        isFirstRank = true
-                    } else { // 1위가 다르다면
-                        cell.resultColorView.backgroundColor = #colorLiteral(red: 0.9411764706, green: 0.4745098039, blue: 0.2352941176, alpha: 0.8)
-                        isFirstRank = false
-                    }
-                } else { // 1위가 아닌 그 이외의 경우
-                    cell.resultColorView.backgroundColor = #colorLiteral(red: 0.2, green: 0.8, blue: 0.5490196078, alpha: 0.8)
-                }
-                */
+                 if firstRankSet.contains(indexPath.row) {
+                 // 작성자 원픽이 1위 or 투표자 투표 이미지가 1위일 경우
+                 if (isSameNickname && object.onePickImageId == indexPath.row) || (loginUserNickname != object.postNickname && object.votedImageId == indexPath.row) {
+                 cell.resultColorView.backgroundColor = #colorLiteral(red: 0.9215686275, green: 0.2862745098, blue: 0.6039215686, alpha: 0.8)
+                 isFirstRank = true
+                 } else { // 1위가 다르다면
+                 cell.resultColorView.backgroundColor = #colorLiteral(red: 0.9411764706, green: 0.4745098039, blue: 0.2352941176, alpha: 0.8)
+                 isFirstRank = false
+                 }
+                 } else { // 1위가 아닌 그 이외의 경우
+                 cell.resultColorView.backgroundColor = #colorLiteral(red: 0.2, green: 0.8, blue: 0.5490196078, alpha: 0.8)
+                 }
+                 */
                 
                 if firstRankSet.contains(indexPath.row) {
                     cell.resultColorView.backgroundColor = firstRankColor
@@ -423,14 +434,14 @@ extension VoteDetailViewController: AlertViewActionDelegate {
                 heightConstraintArray[index].constant = 48
             } else {
                 /*
-                if firstRankSet.contains(currentPage) && isFirstRank { // 1위 = 원픽 or 투표이미지
-                    resultViewArray[index].backgroundColor = #colorLiteral(red: 0.9215686275, green: 0.2862745098, blue: 0.6039215686, alpha: 0.8)
-                } else if firstRankSet.contains(currentPage) && !isFirstRank { // 1위 != 원픽 or 투표이미지
-                    resultViewArray[index].backgroundColor = #colorLiteral(red: 0.9411764706, green: 0.4745098039, blue: 0.2352941176, alpha: 0.8)
-                } else { // 그 외
-                    resultViewArray[index].backgroundColor = #colorLiteral(red: 0.2, green: 0.8, blue: 0.5490196078, alpha: 0.8)
-                }
-                */
+                 if firstRankSet.contains(currentPage) && isFirstRank { // 1위 = 원픽 or 투표이미지
+                 resultViewArray[index].backgroundColor = #colorLiteral(red: 0.9215686275, green: 0.2862745098, blue: 0.6039215686, alpha: 0.8)
+                 } else if firstRankSet.contains(currentPage) && !isFirstRank { // 1위 != 원픽 or 투표이미지
+                 resultViewArray[index].backgroundColor = #colorLiteral(red: 0.9411764706, green: 0.4745098039, blue: 0.2352941176, alpha: 0.8)
+                 } else { // 그 외
+                 resultViewArray[index].backgroundColor = #colorLiteral(red: 0.2, green: 0.8, blue: 0.5490196078, alpha: 0.8)
+                 }
+                 */
                 
                 if firstRankSet.contains(currentPage) {
                     resultViewArray[index].backgroundColor = firstRankColor
@@ -691,14 +702,14 @@ extension VoteDetailViewController {
                 }
             }
         }
-  
+        
         if !isSameNickname && !object.isVoted { // 투표게시자가 아닌데 투표 안했으면 패스
             return
         }
         
         // 1,2,3위 색 판별을 위한 기준 인덱스 - 투표 게시자일 경우 firstPickIndex / 투표자일 경우 votedImageIndex
         let compareIndex = isSameNickname ? object.onePickImageId : object.votedImageId
-     
+        
         if firstRankSet.contains(compareIndex) { // 1,2,3 순위 안에 있을 경우 핑크
             firstRankColor = #colorLiteral(red: 0.9215686275, green: 0.2862745098, blue: 0.6039215686, alpha: 0.8)
         }

--- a/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
+++ b/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
@@ -691,10 +691,14 @@ extension VoteDetailViewController {
                 }
             }
         }
+  
+        if !isSameNickname && !object.isVoted { // 투표게시자가 아닌데 투표 안했으면 패스
+            return
+        }
         
         // 1,2,3위 색 판별을 위한 기준 인덱스 - 투표 게시자일 경우 firstPickIndex / 투표자일 경우 votedImageIndex
         let compareIndex = isSameNickname ? object.onePickImageId : object.votedImageId
-        
+     
         if firstRankSet.contains(compareIndex) { // 1,2,3 순위 안에 있을 경우 핑크
             firstRankColor = #colorLiteral(red: 0.9215686275, green: 0.2862745098, blue: 0.6039215686, alpha: 0.8)
         }

--- a/Picme/Picme/View/Storyboard/Main/Main.storyboard
+++ b/Picme/Picme/View/Storyboard/Main/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zxu-2c-T0e">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
@@ -35,19 +35,19 @@
             <objects>
                 <viewController storyboardIdentifier="MainViewController" id="Y6W-OH-hqX" customClass="MainViewController" customModule="Picme" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="bYY-Zm-ohL">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="44" width="375" height="574"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="sectionIndexBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MainTableViewCell" rowHeight="300" id="rNT-EV-ccY" customClass="MainTableViewCell" customModule="Picme" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="24.5" width="414" height="300"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="375" height="300"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="rNT-EV-ccY" id="yYn-pn-djr">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="300"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="300"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="1" translatesAutoresizingMaskIntoConstraints="NO" id="Mvv-OA-9oz">
@@ -65,7 +65,7 @@
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="ltH-kV-oc5">
-                                                    <rect key="frame" x="0.0" y="97" width="414" height="183"/>
+                                                    <rect key="frame" x="0.0" y="97" width="375" height="183"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="183" id="QOa-23-YuG"/>
                                                     </constraints>
@@ -149,7 +149,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zZa-z8-hjs">
-                                                    <rect key="frame" x="304" y="20" width="90" height="24"/>
+                                                    <rect key="frame" x="265" y="20" width="90" height="24"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="5.2999999999999998" translatesAutoresizingMaskIntoConstraints="NO" id="a8H-fO-XRM" userLabel="Timer Stack View">
                                                             <rect key="frame" x="9" y="3.5" width="72" height="16"/>
@@ -223,7 +223,7 @@
                                 <rect key="frame" x="0.0" y="409" width="414" height="404"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="hmm" translatesAutoresizingMaskIntoConstraints="NO" id="7fd-ST-BGc">
-                                        <rect key="frame" x="183" y="208" width="48" height="48"/>
+                                        <rect key="frame" x="163.5" y="208" width="48" height="48"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="7fd-ST-BGc" secondAttribute="height" multiplier="1:1" id="K8D-k0-Y7c"/>
                                             <constraint firstAttribute="height" constant="48" id="Pmr-TE-put"/>
@@ -231,7 +231,7 @@
                                         </constraints>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xPI-cZ-8Bp">
-                                        <rect key="frame" x="137.5" y="340" width="139" height="44"/>
+                                        <rect key="frame" x="118" y="340" width="139" height="44"/>
                                         <color key="backgroundColor" red="0.92156862745098034" green="0.28627450980392155" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="EPj-Iz-Wtb"/>
@@ -252,7 +252,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="아직 투표가 없네요! 작성자님이 첫 번째 투표를 만들어주세요." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VZ5-1D-wwc">
-                                        <rect key="frame" x="55.5" y="264" width="303" height="48"/>
+                                        <rect key="frame" x="36" y="264" width="303" height="48"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="303" id="45q-H3-aDu"/>
                                             <constraint firstAttribute="height" constant="48" id="5sa-FP-MI2"/>
@@ -274,7 +274,7 @@
                                 </constraints>
                             </view>
                             <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nJX-5u-sb8">
-                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                 <color key="barTintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <textAttributes key="titleTextAttributes">
                                     <color key="textColor" red="0.99607843137254903" green="0.99607843137254903" blue="0.99607843137254903" alpha="1" colorSpace="calibratedRGB"/>
@@ -286,7 +286,7 @@
                                 </items>
                             </navigationBar>
                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pGo-Kk-fLs">
-                                <rect key="frame" x="14.5" y="44" width="157.5" height="44"/>
+                                <rect key="frame" x="14.5" y="0.0" width="157.5" height="44"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="인생샷" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qge-TD-kVp">
                                         <rect key="frame" x="0.0" y="0.0" width="44.5" height="44"/>
@@ -342,11 +342,14 @@
             <objects>
                 <viewController storyboardIdentifier="VoteDetailViewController" id="hjh-eJ-59M" customClass="VoteDetailViewController" customModule="Picme" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="idd-lq-4rt">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4oQ-Hg-wQt">
-                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="cwl-u6-KLO"/>
+                                </constraints>
                                 <color key="barTintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <textAttributes key="titleTextAttributes">
                                     <color key="textColor" red="0.99607843139999996" green="0.99607843139999996" blue="0.99607843139999996" alpha="1" colorSpace="calibratedRGB"/>
@@ -363,7 +366,7 @@
                                 </items>
                             </navigationBar>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="1" translatesAutoresizingMaskIntoConstraints="NO" id="Lge-DT-c9U">
-                                <rect key="frame" x="20" y="112" width="40" height="40"/>
+                                <rect key="frame" x="20" y="68" width="40" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="OlV-F4-J6X"/>
                                     <constraint firstAttribute="width" constant="40" id="VaX-vx-GmT"/>
@@ -371,7 +374,7 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="Khk-tx-YN4" userLabel="Nickname Stack View">
-                                <rect key="frame" x="68" y="109.5" width="81" height="45"/>
+                                <rect key="frame" x="68" y="65.5" width="81" height="45"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Nickname" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xcI-fx-oFf">
                                         <rect key="frame" x="0.0" y="0.0" width="81" height="21"/>
@@ -388,7 +391,7 @@
                                 </subviews>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vTV-am-Nmy" userLabel="Timer View">
-                                <rect key="frame" x="304.5" y="112" width="89.5" height="24"/>
+                                <rect key="frame" x="265.5" y="68" width="89.5" height="24"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Pqd-QZ-YWN" userLabel="Timer Stack View">
                                         <rect key="frame" x="9" y="3.5" width="71.5" height="16"/>
@@ -428,10 +431,10 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lbn-9o-aCP" userLabel="Pick View">
-                                <rect key="frame" x="0.0" y="609.5" width="414" height="87.5"/>
+                                <rect key="frame" x="0.0" y="556.5" width="375" height="87.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="otq-hq-BSA">
-                                        <rect key="frame" x="169.5" y="43.5" width="75" height="44"/>
+                                        <rect key="frame" x="150" y="43.5" width="75" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="FSm-fD-UL3"/>
                                             <constraint firstAttribute="width" constant="75" id="lXb-W3-6BR"/>
@@ -451,7 +454,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </button>
                                     <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="6" translatesAutoresizingMaskIntoConstraints="NO" id="1hK-7q-nex">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="27.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="27.5"/>
                                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <color key="pageIndicatorTintColor" red="0.2156862745" green="0.23529411759999999" blue="0.25882352939999997" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <color key="currentPageIndicatorTintColor" red="0.69803921570000005" green="0.70588235290000001" blue="0.71372549019999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -468,16 +471,22 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cEW-AT-Rkn" userLabel="Title View">
-                                <rect key="frame" x="20" y="184" width="374" height="101.5"/>
+                                <rect key="frame" x="20" y="140" width="335" height="92.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="currentPage/totalPage" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DLK-JD-wXx">
-                                        <rect key="frame" x="124" y="10" width="126" height="18"/>
+                                        <rect key="frame" x="104.5" y="10" width="126" height="18"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="18" id="V5k-Vc-U0R"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" name="NotoSansCJKkr-Regular" family="Noto Sans CJK KR" pointSize="12"/>
                                         <color key="textColor" red="0.69803921570000005" green="0.70588235290000001" blue="0.71372549019999998" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="사진 잘나온 거 한 장만 골라주세요! 최대 공백 포함 45자까지 제한이 걸려있어요!" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mmd-Ur-e39">
-                                        <rect key="frame" x="16" y="38" width="342" height="47.5"/>
+                                        <rect key="frame" x="16" y="33" width="303" height="47.5"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" relation="lessThanOrEqual" constant="47.5" id="lyy-xM-GYY"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="16"/>
                                         <color key="textColor" red="0.99607843139999996" green="0.99607843139999996" blue="0.99607843139999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
@@ -486,9 +495,10 @@
                                 <color key="backgroundColor" red="0.1019607843" green="0.10980392160000001" blue="0.1215686275" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstItem="DLK-JD-wXx" firstAttribute="top" secondItem="cEW-AT-Rkn" secondAttribute="top" constant="10" id="9zk-4P-fRW"/>
-                                    <constraint firstAttribute="bottom" secondItem="mmd-Ur-e39" secondAttribute="bottom" constant="16" id="BeJ-WD-xzd"/>
+                                    <constraint firstAttribute="bottom" secondItem="mmd-Ur-e39" secondAttribute="bottom" constant="12" id="BeJ-WD-xzd"/>
                                     <constraint firstItem="DLK-JD-wXx" firstAttribute="centerX" secondItem="cEW-AT-Rkn" secondAttribute="centerX" id="H5M-u3-g58"/>
-                                    <constraint firstItem="mmd-Ur-e39" firstAttribute="top" secondItem="DLK-JD-wXx" secondAttribute="bottom" constant="10" id="klA-6k-PsH"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="72" id="ewu-Kl-UfS"/>
+                                    <constraint firstItem="mmd-Ur-e39" firstAttribute="top" secondItem="DLK-JD-wXx" secondAttribute="bottom" constant="5" id="klA-6k-PsH"/>
                                     <constraint firstItem="mmd-Ur-e39" firstAttribute="centerX" secondItem="cEW-AT-Rkn" secondAttribute="centerX" id="ntZ-lf-tfb"/>
                                     <constraint firstAttribute="trailing" secondItem="mmd-Ur-e39" secondAttribute="trailing" constant="16" id="yIe-Yj-dJ5"/>
                                     <constraint firstItem="mmd-Ur-e39" firstAttribute="leading" secondItem="cEW-AT-Rkn" secondAttribute="leading" constant="16" id="ygp-jQ-12G"/>
@@ -501,11 +511,11 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="T04-YG-drm" customClass="ScalingCarouselView" customModule="ScalingCarousel">
-                                <rect key="frame" x="0.0" y="309.5" width="414" height="300"/>
+                                <rect key="frame" x="0.0" y="256.5" width="375" height="300"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="300" id="b0J-7e-IBB"/>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="300" id="rp1-lJ-EOI"/>
+                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="300" id="rp1-lJ-EOI"/>
                                 </constraints>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="z8B-7L-A6z">
                                     <size key="itemSize" width="280" height="280"/>
@@ -515,7 +525,7 @@
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="VoteDetailCollectionViewCell" id="ryq-Kc-p5L" customClass="VoteDetailCollectionViewCell" customModule="Picme" customModuleProvider="target">
-                                        <rect key="frame" x="67" y="0.0" width="280" height="280"/>
+                                        <rect key="frame" x="47.5" y="0.0" width="280" height="280"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="yZE-qI-3Ft">
                                             <rect key="frame" x="0.0" y="0.0" width="280" height="280"/>
@@ -528,7 +538,6 @@
                                                             <rect key="frame" x="-9.5" y="-9.5" width="299" height="299"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="299" id="6bJ-cm-Q8W"/>
-                                                                <constraint firstAttribute="width" constant="299" id="DEY-yw-jHm"/>
                                                                 <constraint firstAttribute="width" secondItem="IdT-mW-AiB" secondAttribute="height" multiplier="1:1" id="Xpt-Xc-Pcv"/>
                                                             </constraints>
                                                             <userDefinedRuntimeAttributes>
@@ -661,10 +670,10 @@
                                 </connections>
                             </collectionView>
                             <view hidden="YES" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VvQ-sh-e3K">
-                                <rect key="frame" x="0.0" y="850" width="414" height="46"/>
+                                <rect key="frame" x="0.0" y="813" width="414" height="83"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="u1i-50-UtO">
-                                        <rect key="frame" x="101.5" y="352" width="211.5" height="104"/>
+                                        <rect key="frame" x="82" y="259.5" width="211.5" height="104"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="trash" translatesAutoresizingMaskIntoConstraints="NO" id="EpZ-By-SfV">
                                                 <rect key="frame" x="0.0" y="0.0" width="211.5" height="48.5"/>
@@ -683,15 +692,15 @@
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstItem="u1i-50-UtO" firstAttribute="centerX" secondItem="VvQ-sh-e3K" secondAttribute="centerX" id="0zH-Rd-4HR"/>
-                                    <constraint firstItem="u1i-50-UtO" firstAttribute="centerY" secondItem="VvQ-sh-e3K" secondAttribute="centerY" id="V85-NL-O9d"/>
+                                    <constraint firstItem="u1i-50-UtO" firstAttribute="centerX" secondItem="VvQ-sh-e3K" secondAttribute="centerX" id="abV-9e-eFb"/>
+                                    <constraint firstItem="u1i-50-UtO" firstAttribute="centerY" secondItem="VvQ-sh-e3K" secondAttribute="centerY" id="h4S-KN-15V"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nM7-Ii-Esh" userLabel="Feedback View">
-                                <rect key="frame" x="0.0" y="609.5" width="414" height="100"/>
+                                <rect key="frame" x="0.0" y="556.5" width="375" height="100"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="eFd-LK-A9A" userLabel="Feedback Stack View">
-                                        <rect key="frame" x="67" y="16.5" width="280" height="67"/>
+                                        <rect key="frame" x="47.5" y="16.5" width="280" height="67"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="U2j-ma-Wal" userLabel="Sensitivity Stack View">
                                                 <rect key="frame" x="0.0" y="0.0" width="48" height="67"/>
@@ -943,7 +952,6 @@
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="414" id="8Kv-GY-lrK"/>
                                     <constraint firstItem="eFd-LK-A9A" firstAttribute="centerY" secondItem="nM7-Ii-Esh" secondAttribute="centerY" id="P0R-9U-MFY"/>
                                     <constraint firstItem="eFd-LK-A9A" firstAttribute="centerX" secondItem="nM7-Ii-Esh" secondAttribute="centerX" id="XkH-aT-JEC"/>
                                     <constraint firstAttribute="height" constant="100" id="lj2-Kn-ZpA"/>
@@ -953,9 +961,11 @@
                         <viewLayoutGuide key="safeArea" id="vlC-pT-r26"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
+                            <constraint firstItem="VvQ-sh-e3K" firstAttribute="trailing" secondItem="vlC-pT-r26" secondAttribute="trailing" id="2YK-43-jVG"/>
                             <constraint firstItem="vlC-pT-r26" firstAttribute="trailing" secondItem="vTV-am-Nmy" secondAttribute="trailing" constant="20" id="7VO-de-PwA"/>
                             <constraint firstItem="cEW-AT-Rkn" firstAttribute="leading" secondItem="vlC-pT-r26" secondAttribute="leading" constant="20" id="8Pu-4M-kp3"/>
-                            <constraint firstItem="vlC-pT-r26" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Lbn-9o-aCP" secondAttribute="bottom" constant="20" id="AlV-xd-RWl"/>
+                            <constraint firstItem="VvQ-sh-e3K" firstAttribute="leading" secondItem="vlC-pT-r26" secondAttribute="leading" id="Ej6-xN-vl2"/>
+                            <constraint firstItem="VvQ-sh-e3K" firstAttribute="top" secondItem="4oQ-Hg-wQt" secondAttribute="bottom" id="Fxu-v9-SWq"/>
                             <constraint firstItem="Khk-tx-YN4" firstAttribute="leading" secondItem="Lge-DT-c9U" secondAttribute="trailing" constant="8" id="J1j-xy-zI8"/>
                             <constraint firstItem="vlC-pT-r26" firstAttribute="trailing" secondItem="cEW-AT-Rkn" secondAttribute="trailing" constant="20" id="JQs-2j-gdb"/>
                             <constraint firstItem="T04-YG-drm" firstAttribute="centerX" secondItem="vlC-pT-r26" secondAttribute="centerX" id="K27-SH-PdK"/>
@@ -963,26 +973,25 @@
                             <constraint firstItem="cEW-AT-Rkn" firstAttribute="top" secondItem="Lge-DT-c9U" secondAttribute="bottom" constant="32" id="Okn-X7-2QR"/>
                             <constraint firstItem="nM7-Ii-Esh" firstAttribute="trailing" secondItem="vlC-pT-r26" secondAttribute="trailing" id="PFY-lG-Ugg"/>
                             <constraint firstItem="cEW-AT-Rkn" firstAttribute="centerX" secondItem="vlC-pT-r26" secondAttribute="centerX" id="PUE-M0-BFI"/>
-                            <constraint firstItem="VvQ-sh-e3K" firstAttribute="top" secondItem="4oQ-Hg-wQt" secondAttribute="bottom" id="QXY-Dl-Bao"/>
                             <constraint firstItem="vTV-am-Nmy" firstAttribute="top" secondItem="Lge-DT-c9U" secondAttribute="top" id="RMn-bd-El6"/>
                             <constraint firstItem="Lge-DT-c9U" firstAttribute="leading" secondItem="vlC-pT-r26" secondAttribute="leading" constant="20" id="UH4-hW-ylF"/>
                             <constraint firstItem="T04-YG-drm" firstAttribute="trailing" secondItem="vlC-pT-r26" secondAttribute="trailing" id="Vff-me-SsA"/>
+                            <constraint firstAttribute="bottom" secondItem="VvQ-sh-e3K" secondAttribute="bottom" id="YDN-9N-jC7"/>
                             <constraint firstItem="T04-YG-drm" firstAttribute="width" secondItem="idd-lq-4rt" secondAttribute="width" id="a6a-hC-afN"/>
+                            <constraint firstItem="vlC-pT-r26" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Lbn-9o-aCP" secondAttribute="bottom" id="cOg-AW-3fN"/>
                             <constraint firstItem="Lge-DT-c9U" firstAttribute="top" secondItem="4oQ-Hg-wQt" secondAttribute="bottom" constant="24" id="ecY-Lu-eaQ"/>
                             <constraint firstItem="Lbn-9o-aCP" firstAttribute="leading" secondItem="vlC-pT-r26" secondAttribute="leading" id="fCL-p8-pjM"/>
                             <constraint firstItem="vTV-am-Nmy" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Khk-tx-YN4" secondAttribute="trailing" constant="60" id="fUH-jh-GRf"/>
                             <constraint firstItem="Lbn-9o-aCP" firstAttribute="top" secondItem="T04-YG-drm" secondAttribute="bottom" id="gQN-uH-ZoX"/>
                             <constraint firstItem="T04-YG-drm" firstAttribute="leading" secondItem="vlC-pT-r26" secondAttribute="leading" id="gv3-gd-jI6"/>
-                            <constraint firstAttribute="bottom" secondItem="VvQ-sh-e3K" secondAttribute="bottom" id="hU4-4T-yjn"/>
-                            <constraint firstItem="VvQ-sh-e3K" firstAttribute="leading" secondItem="vlC-pT-r26" secondAttribute="leading" id="jJm-Hh-HRO"/>
                             <constraint firstItem="nM7-Ii-Esh" firstAttribute="leading" secondItem="vlC-pT-r26" secondAttribute="leading" id="n5w-OV-ioU"/>
                             <constraint firstItem="Khk-tx-YN4" firstAttribute="centerY" secondItem="Lge-DT-c9U" secondAttribute="centerY" id="oeF-LL-oJl"/>
+                            <constraint firstItem="vlC-pT-r26" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="nM7-Ii-Esh" secondAttribute="bottom" id="s8j-rx-GZG"/>
                             <constraint firstItem="4oQ-Hg-wQt" firstAttribute="trailing" secondItem="vlC-pT-r26" secondAttribute="trailing" id="sQf-gh-PqZ"/>
                             <constraint firstItem="Lbn-9o-aCP" firstAttribute="trailing" secondItem="vlC-pT-r26" secondAttribute="trailing" id="sRs-I8-cY1"/>
-                            <constraint firstItem="vlC-pT-r26" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="nM7-Ii-Esh" secondAttribute="bottom" constant="20" id="seb-F7-wdx"/>
-                            <constraint firstItem="VvQ-sh-e3K" firstAttribute="trailing" secondItem="vlC-pT-r26" secondAttribute="trailing" id="vJX-fN-0CJ"/>
                             <constraint firstItem="4oQ-Hg-wQt" firstAttribute="top" secondItem="vlC-pT-r26" secondAttribute="top" id="vY2-Ps-7gB"/>
                             <constraint firstItem="nM7-Ii-Esh" firstAttribute="top" secondItem="T04-YG-drm" secondAttribute="bottom" id="vg9-8v-cFf"/>
+                            <constraint firstItem="VvQ-sh-e3K" firstAttribute="centerX" secondItem="vlC-pT-r26" secondAttribute="centerX" id="wqT-Iq-UOz"/>
                             <constraint firstItem="T04-YG-drm" firstAttribute="top" secondItem="cEW-AT-Rkn" secondAttribute="bottom" constant="24" id="z95-Fo-U1p"/>
                         </constraints>
                     </view>

--- a/Picme/Picme/View/Storyboard/Main/Main.storyboard
+++ b/Picme/Picme/View/Storyboard/Main/Main.storyboard
@@ -660,8 +660,35 @@
                                     <outlet property="delegate" destination="hjh-eJ-59M" id="ww0-jJ-Epk"/>
                                 </connections>
                             </collectionView>
-                            <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nM7-Ii-Esh" userLabel="Feedback View">
-                                <rect key="frame" x="0.0" y="762" width="414" height="100"/>
+                            <view hidden="YES" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VvQ-sh-e3K">
+                                <rect key="frame" x="0.0" y="850" width="414" height="46"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="u1i-50-UtO">
+                                        <rect key="frame" x="101.5" y="352" width="211.5" height="104"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="trash" translatesAutoresizingMaskIntoConstraints="NO" id="EpZ-By-SfV">
+                                                <rect key="frame" x="0.0" y="0.0" width="211.5" height="48.5"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="EpZ-By-SfV" secondAttribute="height" multiplier="211:48" id="0Ii-Qe-IwR"/>
+                                                </constraints>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="게시글이 삭제되어 볼 수 없어요. 홈으로 돌아가주세요." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="29Q-7Z-PQY">
+                                                <rect key="frame" x="0.0" y="56.5" width="211.5" height="47.5"/>
+                                                <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="16"/>
+                                                <color key="textColor" red="0.30196078431372547" green="0.30980392156862746" blue="0.32156862745098036" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="u1i-50-UtO" firstAttribute="centerX" secondItem="VvQ-sh-e3K" secondAttribute="centerX" id="0zH-Rd-4HR"/>
+                                    <constraint firstItem="u1i-50-UtO" firstAttribute="centerY" secondItem="VvQ-sh-e3K" secondAttribute="centerY" id="V85-NL-O9d"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nM7-Ii-Esh" userLabel="Feedback View">
+                                <rect key="frame" x="0.0" y="609.5" width="414" height="100"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="eFd-LK-A9A" userLabel="Feedback Stack View">
                                         <rect key="frame" x="67" y="16.5" width="280" height="67"/>
@@ -922,39 +949,13 @@
                                     <constraint firstAttribute="height" constant="100" id="lj2-Kn-ZpA"/>
                                 </constraints>
                             </view>
-                            <view hidden="YES" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VvQ-sh-e3K">
-                                <rect key="frame" x="0.0" y="850" width="414" height="46"/>
-                                <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="u1i-50-UtO">
-                                        <rect key="frame" x="101.5" y="352" width="211.5" height="104"/>
-                                        <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="trash" translatesAutoresizingMaskIntoConstraints="NO" id="EpZ-By-SfV">
-                                                <rect key="frame" x="0.0" y="0.0" width="211.5" height="48.5"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" secondItem="EpZ-By-SfV" secondAttribute="height" multiplier="211:48" id="0Ii-Qe-IwR"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="게시글이 삭제되어 볼 수 없어요. 홈으로 돌아가주세요." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="29Q-7Z-PQY">
-                                                <rect key="frame" x="0.0" y="56.5" width="211.5" height="47.5"/>
-                                                <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="16"/>
-                                                <color key="textColor" red="0.30196078431372547" green="0.30980392156862746" blue="0.32156862745098036" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
-                                </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="u1i-50-UtO" firstAttribute="centerX" secondItem="VvQ-sh-e3K" secondAttribute="centerX" id="0zH-Rd-4HR"/>
-                                    <constraint firstItem="u1i-50-UtO" firstAttribute="centerY" secondItem="VvQ-sh-e3K" secondAttribute="centerY" id="V85-NL-O9d"/>
-                                </constraints>
-                            </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="vlC-pT-r26"/>
                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="vlC-pT-r26" firstAttribute="trailing" secondItem="vTV-am-Nmy" secondAttribute="trailing" constant="20" id="7VO-de-PwA"/>
                             <constraint firstItem="cEW-AT-Rkn" firstAttribute="leading" secondItem="vlC-pT-r26" secondAttribute="leading" constant="20" id="8Pu-4M-kp3"/>
+                            <constraint firstItem="vlC-pT-r26" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Lbn-9o-aCP" secondAttribute="bottom" constant="20" id="AlV-xd-RWl"/>
                             <constraint firstItem="Khk-tx-YN4" firstAttribute="leading" secondItem="Lge-DT-c9U" secondAttribute="trailing" constant="8" id="J1j-xy-zI8"/>
                             <constraint firstItem="vlC-pT-r26" firstAttribute="trailing" secondItem="cEW-AT-Rkn" secondAttribute="trailing" constant="20" id="JQs-2j-gdb"/>
                             <constraint firstItem="T04-YG-drm" firstAttribute="centerX" secondItem="vlC-pT-r26" secondAttribute="centerX" id="K27-SH-PdK"/>
@@ -978,6 +979,7 @@
                             <constraint firstItem="Khk-tx-YN4" firstAttribute="centerY" secondItem="Lge-DT-c9U" secondAttribute="centerY" id="oeF-LL-oJl"/>
                             <constraint firstItem="4oQ-Hg-wQt" firstAttribute="trailing" secondItem="vlC-pT-r26" secondAttribute="trailing" id="sQf-gh-PqZ"/>
                             <constraint firstItem="Lbn-9o-aCP" firstAttribute="trailing" secondItem="vlC-pT-r26" secondAttribute="trailing" id="sRs-I8-cY1"/>
+                            <constraint firstItem="vlC-pT-r26" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="nM7-Ii-Esh" secondAttribute="bottom" constant="20" id="seb-F7-wdx"/>
                             <constraint firstItem="VvQ-sh-e3K" firstAttribute="trailing" secondItem="vlC-pT-r26" secondAttribute="trailing" id="vJX-fN-0CJ"/>
                             <constraint firstItem="4oQ-Hg-wQt" firstAttribute="top" secondItem="vlC-pT-r26" secondAttribute="top" id="vY2-Ps-7gB"/>
                             <constraint firstItem="nM7-Ii-Esh" firstAttribute="top" secondItem="T04-YG-drm" secondAttribute="bottom" id="vg9-8v-cFf"/>

--- a/Picme/Picme/View/Storyboard/MyPage/MyPage.storyboard
+++ b/Picme/Picme/View/Storyboard/MyPage/MyPage.storyboard
@@ -113,9 +113,6 @@
                                             <constraint firstAttribute="width" secondItem="rf8-uR-HyQ" secondAttribute="height" multiplier="17:22" id="u3v-ew-8M6"/>
                                         </constraints>
                                         <state key="normal" image="settingsButton"/>
-                                        <connections>
-                                            <segue destination="aop-3v-K0U" kind="push" id="lwu-hq-WHu"/>
-                                        </connections>
                                     </button>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="profilePink" translatesAutoresizingMaskIntoConstraints="NO" id="irn-8S-9ZD">
                                         <rect key="frame" x="17" y="24" width="44" height="44"/>
@@ -265,14 +262,14 @@
             <objects>
                 <viewController id="aop-3v-K0U" customClass="SettingViewController" customModule="Picme" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="JPz-61-Jq3">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="808"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZGB-Xy-tOH">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="690"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="734"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="최대 12자까지 자유롭게 입력해주세요" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="BDp-v7-1bs">
-                                        <rect key="frame" x="39.5" y="319" width="335" height="52"/>
+                                        <rect key="frame" x="39.5" y="341" width="335" height="52"/>
                                         <color key="backgroundColor" red="0.10196078431372549" green="0.10980392156862745" blue="0.12156862745098039" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="52" id="DcA-tZ-EBq"/>
@@ -292,19 +289,19 @@
                                         </userDefinedRuntimeAttributes>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="닉네임 수정" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YV9-lp-xiq">
-                                        <rect key="frame" x="39.5" y="287" width="78.5" height="24"/>
+                                        <rect key="frame" x="39.5" y="309" width="78.5" height="24"/>
                                         <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="16"/>
                                         <color key="textColor" red="0.92156862750000001" green="0.28627450980000002" blue="0.60392156860000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0/12" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9IQ-fO-hwf">
-                                        <rect key="frame" x="345.5" y="288.5" width="29" height="21"/>
+                                        <rect key="frame" x="345.5" y="310.5" width="29" height="21"/>
                                         <fontDescription key="fontDescription" name="NotoSansCJKkr-Regular" family="Noto Sans CJK KR" pointSize="14"/>
                                         <color key="textColor" red="0.30196078431372547" green="0.30980392156862746" blue="0.32156862745098036" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="앗, 이미 다른 사람이 사용하고 있는 닉네임이에요!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xrv-c1-LSD">
-                                        <rect key="frame" x="39.5" y="379" width="247.5" height="18"/>
+                                        <rect key="frame" x="39.5" y="401" width="247.5" height="18"/>
                                         <fontDescription key="fontDescription" name="NotoSansCJKkr-Regular" family="Noto Sans CJK KR" pointSize="12"/>
                                         <color key="textColor" red="0.92156862750000001" green="0.28627450980000002" blue="0.60392156860000001" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
@@ -323,7 +320,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hLW-ig-3H3">
-                                <rect key="frame" x="39.5" y="690" width="335" height="52"/>
+                                <rect key="frame" x="39.5" y="778" width="335" height="52"/>
                                 <color key="backgroundColor" red="0.2156862745" green="0.23529411759999999" blue="0.25882352939999997" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="52" id="14o-Tu-taD"/>


### PR DESCRIPTION
- 투표 상세 결과 뷰 색상 변경
- 아이폰8, SE 등 작은 화면의 기기일 경우 투표 상세 화면에서 탭바 사라지도록 변경
- 메인에서 ViewDidLoad시에만 서버와 통신하도록 변경
- 투표 생성 후 메인으로 돌아올 때 서버와 통신할 수 있도록 변경
- 일부 스위프트린트 오류 수정