### PR TITLE
투표 상세, 메인 관련 버그 수정

### DIFF
--- a/Picme/Picme/View/Controller/Main/Cell/MainTableViewCell.swift
+++ b/Picme/Picme/View/Controller/Main/Cell/MainTableViewCell.swift
@@ -122,7 +122,7 @@ extension MainTableViewCell: UICollectionViewDelegate, UICollectionViewDataSourc
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if let cellDelegate = cellDelegate {
-            cellDelegate.selectedCVCell(indexPath.item, postId)
+            cellDelegate.selectedCVCell(mainCollectionView.tag, postId)
         }
     }
     

--- a/Picme/Picme/View/Controller/Main/MainViewController.swift
+++ b/Picme/Picme/View/Controller/Main/MainViewController.swift
@@ -68,15 +68,13 @@ class MainViewController: BaseViewContoller, UITableViewDelegate {
 
     }
     
-    @objc func backToMain() {
+    @objc func backToMain() { // 투표 상세에서 삭제하고 돌아왔을 때 실행
         mainTableView.beginUpdates()
         let indexPath = IndexPath(row: postIndex, section: 0)
         viewModel.mainList.remove(at: postIndex)
         viewModel.totalCount -= 1
         mainTableView.deleteRows(at: [indexPath], with: .fade)
         mainTableView.endUpdates()
-        
-        print("noti post index : \(postIndex)")
     }
     
     func initViewModel() {
@@ -151,7 +149,6 @@ extension MainViewController: UITableViewDataSource, CollectionViewCellDelegate 
             guard let voteDetailVC = self.storyboard?.instantiateViewController(withIdentifier: "VoteDetailViewController") as? VoteDetailViewController else { return }
             voteDetailVC.postId = postId
             postIndex = index
-            print("* index! : \(index)")
             self.navigationController?.pushViewController(voteDetailVC, animated: true)
         }
     }

--- a/Picme/Picme/View/Controller/Main/MainViewController.swift
+++ b/Picme/Picme/View/Controller/Main/MainViewController.swift
@@ -40,6 +40,8 @@ class MainViewController: BaseViewContoller, UITableViewDelegate {
     var dateHelper = DateHelper()
     let currentDate = Date()
     
+    var postIndex: Int = 0 // 게시물 삭제시 삭제할 게시물의 인덱스를 저장하기 위해 사용
+    
     override func viewDidLoad() {
         super.viewDidLoad()
      
@@ -61,6 +63,20 @@ class MainViewController: BaseViewContoller, UITableViewDelegate {
         super.viewWillAppear(animated)
         
         self.tabBarController?.tabBar.isHidden = false
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(backToMain), name: .backToMain, object: nil)
+
+    }
+    
+    @objc func backToMain() {
+        mainTableView.beginUpdates()
+        let indexPath = IndexPath(row: postIndex, section: 0)
+        viewModel.mainList.remove(at: postIndex)
+        viewModel.totalCount -= 1
+        mainTableView.deleteRows(at: [indexPath], with: .fade)
+        mainTableView.endUpdates()
+        
+        print("noti post index : \(postIndex)")
     }
     
     func initViewModel() {
@@ -117,12 +133,14 @@ extension MainViewController: UITableViewDataSource, CollectionViewCellDelegate 
             createTimer()
             cell.currentDate = Date() // 여기서 현재 시간 초기화를 해줘야지 매번 올바르게 마감시간 설정 가능
             
+            cell.mainCollectionView.tag = indexPath.row
+            
             cell.configure(with: viewModel.mainModel(at: indexPath.row))
         }
         
         return cell
     }
-    
+
     // MARK: - Collection View Cell Delegate - Collection View Cell 클릭시 실행
     
     func selectedCVCell(_ index: Int, _ postId: String) {
@@ -132,6 +150,8 @@ extension MainViewController: UITableViewDataSource, CollectionViewCellDelegate 
         } else { // 로그인한 사용자
             guard let voteDetailVC = self.storyboard?.instantiateViewController(withIdentifier: "VoteDetailViewController") as? VoteDetailViewController else { return }
             voteDetailVC.postId = postId
+            postIndex = index
+            print("* index! : \(index)")
             self.navigationController?.pushViewController(voteDetailVC, animated: true)
         }
     }
@@ -266,4 +286,8 @@ extension MainViewController: TableViewCellDelegate {
             }
         }
     }
+}
+
+extension Notification.Name {
+    static let backToMain = Notification.Name("backToMain")
 }

--- a/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
+++ b/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
@@ -587,8 +587,9 @@ extension VoteDetailViewController: AlertViewActionDelegate {
             } else { // 투표자일 경우
                 if viewModel.voteDetailModel.value.isVoted { // 투표한 경우 - 투표한 이미지 인덱스로 이동
                     carouselCollectionView.scrollToItem(at: IndexPath(row: viewModel.voteDetailModel.value.votedImageId, section: 0), at: .top, animated: true)
-                } else { // 투표하지 않은 경우 - 투표 작성자 원픽 이미지 인덱스로 이동
-                    carouselCollectionView.scrollToItem(at: IndexPath(row: viewModel.voteDetailModel.value.onePickImageId, section: 0), at: .top, animated: true)
+                } else {
+//                    // 투표하지 않은 경우 - 투표 작성자 원픽 이미지 인덱스로 이동
+//                    carouselCollectionView.scrollToItem(at: IndexPath(row: viewModel.voteDetailModel.value.onePickImageId, section: 0), at: .top, animated: true)
                 }
             }
         }

--- a/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
+++ b/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
@@ -259,37 +259,26 @@ extension CarouselDatasource: UICollectionViewDataSource {
                 let size = 239 * 0.01 * (voteResultModel[indexPath.row].percent) + 60
                 cell.viewWidthConstraint.constant = CGFloat(size)
                 
-                // 1위 이미지일 경우
-                /*
-                 if firstRankSet.contains(indexPath.row) {
-                 // 작성자 원픽이 1위 or 투표자 투표 이미지가 1위일 경우
-                 if (isSameNickname && object.onePickImageId == indexPath.row) || (loginUserNickname != object.postNickname && object.votedImageId == indexPath.row) {
-                 cell.resultColorView.backgroundColor = #colorLiteral(red: 0.9215686275, green: 0.2862745098, blue: 0.6039215686, alpha: 0.8)
-                 isFirstRank = true
-                 } else { // 1위가 다르다면
-                 cell.resultColorView.backgroundColor = #colorLiteral(red: 0.9411764706, green: 0.4745098039, blue: 0.2352941176, alpha: 0.8)
-                 isFirstRank = false
-                 }
-                 } else { // 1위가 아닌 그 이외의 경우
-                 cell.resultColorView.backgroundColor = #colorLiteral(red: 0.2, green: 0.8, blue: 0.5490196078, alpha: 0.8)
-                 }
-                 */
-                
-                print("* first rank set")
-                for index in 0..<firstRankSet.count {
-                    print(index)
-                }
-                
+                // 각 사용자별 1,2,3위 이미지일 경우
                 if firstRankSet.contains(indexPath.row) {
                     cell.resultColorView.backgroundColor = firstRankColor
-                    print("true")
                 } else {
                     cell.resultColorView.backgroundColor = #colorLiteral(red: 0.2, green: 0.8, blue: 0.5490196078, alpha: 0.8)
-                    print("false")
                 }
             }
         } else { // 2-1. 마감되지 않고, 투표 안한 사용자 -> 투표 선택 화면 Pick View
-            if isSelect {
+//            if isSelect {
+//                // 투표는 안했지만 선택한 이미지가 있는 경우 -> 핑크 다이아몬드 이미지 활성화
+//                if indexPath.item == selectImageIndex {
+//                    cell.viewWidthConstraint.constant = 299
+//                    cell.diamondsImageView.isHidden = false
+//                } else { // 나머지 이미지는 그대로
+//                    cell.viewWidthConstraint.constant = 0
+//                    cell.diamondsImageView.isHidden = true
+//                }
+//            }
+            
+            if isSelect { // 2-1. 마감되지 않고, 투표 안한 사용자 -> 투표 선택 화면 Pick View
                 // 투표는 안했지만 선택한 이미지가 있는 경우 -> 핑크 다이아몬드 이미지 활성화
                 if indexPath.item == selectImageIndex {
                     cell.viewWidthConstraint.constant = 299
@@ -298,6 +287,9 @@ extension CarouselDatasource: UICollectionViewDataSource {
                     cell.viewWidthConstraint.constant = 0
                     cell.diamondsImageView.isHidden = true
                 }
+            } else {
+                cell.viewWidthConstraint.constant = 0
+                cell.diamondsImageView.isHidden = true
             }
         }
         
@@ -323,9 +315,30 @@ extension VoteDetailViewController: UICollectionViewDelegate {
     // MARK: - Did Select Item At
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        isSelect = true
-        selectImageIndex = indexPath.row
-        selectedImageId = viewModel.voteDetailModel.value.images[indexPath.row].imageId
+//        isSelect = true
+//        selectImageIndex = indexPath.row
+//        selectedImageId = viewModel.voteDetailModel.value.images[indexPath.row].imageId
+//        pickButton.setImage(#imageLiteral(resourceName: "pickButtonNormal"), for: .normal)
+//        carouselCollectionView.reloadData() // 컬렉션 뷰 업데이트 해줘야지 반영됨
+        
+        if !isSelect { // 투표 사진을 선택하지 않은 경우
+            initPickView(index: indexPath.row)
+            carouselCollectionView.reloadData() // 컬렉션 뷰 업데이트 해줘야지 반영됨
+        } else { // 이미 투표한 사진을 다시 선택한 경우
+            if selectImageIndex == indexPath.row {
+                isSelect = false
+                pickButton.setImage(#imageLiteral(resourceName: "pickButtonDisabled"), for: .normal)
+                carouselCollectionView.reloadData()
+            } else { // 투표한 상태에서 다른 사진을 선택한 경우
+                initPickView(index: indexPath.row)
+            }
+        }
+    }
+    
+    func initPickView(index: Int) {
+        isSelect = true // 선택했다고 true 변경 후 관련 인덱스 저장 및 픽 버튼 활성화
+        selectImageIndex = index
+        selectedImageId = viewModel.voteDetailModel.value.images[index].imageId
         pickButton.setImage(#imageLiteral(resourceName: "pickButtonNormal"), for: .normal)
         carouselCollectionView.reloadData() // 컬렉션 뷰 업데이트 해줘야지 반영됨
     }

--- a/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
+++ b/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
@@ -137,6 +137,15 @@ class VoteDetailViewController: BaseViewContoller {
         }
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        
+        // 투표 삭제 후 메인으로 갈 경우 
+        if !deleteView.isHidden {
+            NotificationCenter.default.post(name: .backToMain, object: nil)
+        }
+    }
+    
     // MARK: - Bind View Model
     
     private func bindViewModel() {
@@ -271,7 +280,6 @@ extension CarouselDatasource: UICollectionViewDataSource {
                     print(index)
                 }
                 
-                print("index path : \(indexPath.row)")
                 if firstRankSet.contains(indexPath.row) {
                     cell.resultColorView.backgroundColor = firstRankColor
                     print("true")
@@ -613,18 +621,6 @@ extension VoteDetailViewController: AlertViewActionDelegate {
                 self.deleteView.isHidden = false
                 self.rightBarButton.isEnabled = false
                 Toast.show(using: .remove, controller: self)
-                
-                guard let sceneDelegate = UIApplication.shared.connectedScenes.first!.delegate as? SceneDelegate, let rootVC = sceneDelegate.window?.rootViewController else { return }
-                
-                if let tabbarVC = rootVC as? UITabBarController,
-                   let mainNav = tabbarVC.selectedViewController as? UINavigationController,
-                   let mainVC = mainNav.topViewController as? MainViewController {
-                    
-                    print("* main VC")
-                    
-                    mainVC.mainTableView.scrollToTop()
-                    mainVC.initViewModel()
-                }
             }
         })
     }

--- a/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
+++ b/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
@@ -114,9 +114,7 @@ class VoteDetailViewController: BaseViewContoller {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        print("* token : \(APIConstants.jwtToken)")
-        
+   
         setConfiguration()
         setupButton()
         createTimer()
@@ -466,18 +464,6 @@ extension VoteDetailViewController: AlertViewActionDelegate {
                 resultViewArray[index].backgroundColor = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 0.5)
                 heightConstraintArray[index].constant = 48
             } else {
-                /*
-                 if firstRankSet.contains(currentPage) && isFirstRank { // 1위 = 원픽 or 투표이미지
-                 resultViewArray[index].backgroundColor = #colorLiteral(red: 0.9215686275, green: 0.2862745098, blue: 0.6039215686, alpha: 0.8)
-                 } else if firstRankSet.contains(currentPage) && !isFirstRank { // 1위 != 원픽 or 투표이미지
-                 resultViewArray[index].backgroundColor = #colorLiteral(red: 0.9411764706, green: 0.4745098039, blue: 0.2352941176, alpha: 0.8)
-                 } else { // 그 외
-                 resultViewArray[index].backgroundColor = #colorLiteral(red: 0.2, green: 0.8, blue: 0.5490196078, alpha: 0.8)
-                 }
-                 */
-                
-                print("current page : \(currentPage)")
-                
                 if firstRankSet.contains(currentPage) {
                     resultViewArray[index].backgroundColor = firstRankColor
                 } else {
@@ -699,9 +685,6 @@ extension VoteDetailViewController {
         }
         
         let sortedDitionary = dictionary.sorted { $0.1 > $1.1 }
-        
-        print("* diction : ")
-        print(sortedDitionary)
         
         // 공동 순위 정리
         var rank = 1

--- a/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
+++ b/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
@@ -83,7 +83,7 @@ class VoteDetailViewController: BaseViewContoller {
     var isFirstRank: Bool = false // 1위 이미지가 원픽 이미지 or 투표한 이미지일 경우 true
     var firstRankColor = #colorLiteral(red: 0.9411764706, green: 0.4745098039, blue: 0.2352941176, alpha: 0.8)
     
-    var currentPage: Int = 1 // 현재 중앙에 보이는 컬렉션뷰 이미지의 IndexPath.row 값
+    var currentPage: Int = 0 // 현재 중앙에 보이는 컬렉션뷰 이미지의 IndexPath.row 값
     
     var isPick: Bool = false // pick 버튼 클릭한 경우만 피드백 뷰를 보여주기 위한 Bool 값 - true면 Feedback View 보여줌
     var isPickStart: Bool = false // Pick View에서 이미지 선택한 경우만 투표하기 통신을 하게 하기위한 Bool 값
@@ -153,7 +153,7 @@ class VoteDetailViewController: BaseViewContoller {
                 self.detailNicknameLabel.text = response.postNickname
                 self.detailProfileImageView.image = UIImage.profileImage(response.postProfileUrl)
                 self.detailParticipantsLabel.text = "\(response.participantsNum)명 참여중"
-                self.detailPageLabel.text = "\(self.currentPage)/\(response.images.count)"
+                self.detailPageLabel.text = "\(self.currentPage + 1)/\(response.images.count)"
                 self.detailTitleLabel.text = response.title
                 self.detailTitleLabel.lineBreakMode = .byCharWrapping
                 
@@ -192,6 +192,7 @@ class VoteDetailViewController: BaseViewContoller {
                 }
                 
                 self.setupView() // 결과값 계산 후 Feedback View 퍼센트 초기화 해야함
+      
                 self.carouselCollectionView.reloadData()
         }
      
@@ -420,7 +421,7 @@ extension VoteDetailViewController: AlertViewActionDelegate {
             onePickLabel.text = "내 원픽!"
             onePickLabel.textColor = .textColor(.text91)
             
-            setupResultViewPercent(currentPage: currentPage) // 처음 보여줄 이미지의 피드백뷰 퍼센트 값 설정 
+            setupResultViewPercent(currentPage: currentPage) // 처음 보여줄 이미지의 피드백뷰 퍼센트 값 설정
         }
     }
     

--- a/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
+++ b/Picme/Picme/View/Controller/VoteDetail/VoteDetailViewController.swift
@@ -83,7 +83,7 @@ class VoteDetailViewController: BaseViewContoller {
     var isFirstRank: Bool = false // 1위 이미지가 원픽 이미지 or 투표한 이미지일 경우 true
     var firstRankColor = #colorLiteral(red: 0.9411764706, green: 0.4745098039, blue: 0.2352941176, alpha: 0.8)
     
-    var currentPage: Int = 0 // 현재 중앙에 보이는 컬렉션뷰 이미지의 IndexPath.row 값
+    var currentPage: Int = 1 // 현재 중앙에 보이는 컬렉션뷰 이미지의 IndexPath.row 값
     
     var isPick: Bool = false // pick 버튼 클릭한 경우만 피드백 뷰를 보여주기 위한 Bool 값 - true면 Feedback View 보여줌
     var isPickStart: Bool = false // Pick View에서 이미지 선택한 경우만 투표하기 통신을 하게 하기위한 Bool 값

--- a/Picme/Picme/View/Storyboard/Main/Main.storyboard
+++ b/Picme/Picme/View/Storyboard/Main/Main.storyboard
@@ -470,225 +470,6 @@
                                     <constraint firstItem="1hK-7q-nex" firstAttribute="width" secondItem="Lbn-9o-aCP" secondAttribute="width" id="yVX-6t-wAC"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cEW-AT-Rkn" userLabel="Title View">
-                                <rect key="frame" x="20" y="184" width="374" height="45"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0/0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DLK-JD-wXx">
-                                        <rect key="frame" x="178" y="10" width="18.5" height="18"/>
-                                        <fontDescription key="fontDescription" name="NotoSansCJKkr-Regular" family="Noto Sans CJK KR" pointSize="12"/>
-                                        <color key="textColor" red="0.69803921570000005" green="0.70588235290000001" blue="0.71372549019999998" alpha="1" colorSpace="calibratedRGB"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mmd-Ur-e39">
-                                        <rect key="frame" x="16" y="33" width="342" height="0.0"/>
-                                        <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="16"/>
-                                        <color key="textColor" red="0.99607843139999996" green="0.99607843139999996" blue="0.99607843139999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                </subviews>
-                                <color key="backgroundColor" red="0.1019607843" green="0.10980392160000001" blue="0.1215686275" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                <constraints>
-                                    <constraint firstItem="DLK-JD-wXx" firstAttribute="top" secondItem="cEW-AT-Rkn" secondAttribute="top" constant="10" id="9zk-4P-fRW"/>
-                                    <constraint firstAttribute="bottom" secondItem="mmd-Ur-e39" secondAttribute="bottom" constant="12" id="BeJ-WD-xzd"/>
-                                    <constraint firstItem="DLK-JD-wXx" firstAttribute="centerX" secondItem="cEW-AT-Rkn" secondAttribute="centerX" id="H5M-u3-g58"/>
-                                    <constraint firstItem="mmd-Ur-e39" firstAttribute="top" secondItem="DLK-JD-wXx" secondAttribute="bottom" constant="5" id="klA-6k-PsH"/>
-                                    <constraint firstItem="mmd-Ur-e39" firstAttribute="centerX" secondItem="cEW-AT-Rkn" secondAttribute="centerX" id="ntZ-lf-tfb"/>
-                                    <constraint firstAttribute="trailing" secondItem="mmd-Ur-e39" secondAttribute="trailing" constant="16" id="yIe-Yj-dJ5"/>
-                                    <constraint firstItem="mmd-Ur-e39" firstAttribute="leading" secondItem="cEW-AT-Rkn" secondAttribute="leading" constant="16" id="ygp-jQ-12G"/>
-                                </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="10"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </view>
-                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="T04-YG-drm" customClass="ScalingCarouselView" customModule="ScalingCarousel">
-                                <rect key="frame" x="0.0" y="253" width="414" height="300"/>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="300" id="b0J-7e-IBB"/>
-                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="300" id="rp1-lJ-EOI"/>
-                                </constraints>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="z8B-7L-A6z">
-                                    <size key="itemSize" width="280" height="280"/>
-                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
-                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                </collectionViewFlowLayout>
-                                <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="VoteDetailCollectionViewCell" id="ryq-Kc-p5L" customClass="VoteDetailCollectionViewCell" customModule="Picme" customModuleProvider="target">
-                                        <rect key="frame" x="67" y="0.0" width="280" height="280"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="yZE-qI-3Ft">
-                                            <rect key="frame" x="0.0" y="0.0" width="280" height="280"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                            <subviews>
-                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fkq-8O-qEk">
-                                                    <rect key="frame" x="0.0" y="0.0" width="280" height="280"/>
-                                                    <subviews>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="IdT-mW-AiB">
-                                                            <rect key="frame" x="-9.5" y="-9.5" width="299" height="299"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="299" id="6bJ-cm-Q8W"/>
-                                                                <constraint firstAttribute="width" secondItem="IdT-mW-AiB" secondAttribute="height" multiplier="1:1" id="Xpt-Xc-Pcv"/>
-                                                            </constraints>
-                                                            <userDefinedRuntimeAttributes>
-                                                                <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
-                                                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                                    <integer key="value" value="10"/>
-                                                                </userDefinedRuntimeAttribute>
-                                                            </userDefinedRuntimeAttributes>
-                                                        </imageView>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0pu-gY-xby">
-                                                            <rect key="frame" x="-9.5" y="0.0" width="0.0" height="280"/>
-                                                            <color key="backgroundColor" red="0.92156862745098034" green="0.41176470588235292" blue="0.6588235294117647" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" id="FU1-Zg-R3B"/>
-                                                            </constraints>
-                                                            <userDefinedRuntimeAttributes>
-                                                                <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
-                                                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                                    <integer key="value" value="10"/>
-                                                                </userDefinedRuntimeAttribute>
-                                                            </userDefinedRuntimeAttributes>
-                                                        </view>
-                                                        <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="diamonds" translatesAutoresizingMaskIntoConstraints="NO" id="egU-Zk-Ngg">
-                                                            <rect key="frame" x="107.5" y="104.5" width="65" height="71"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" secondItem="egU-Zk-Ngg" secondAttribute="height" multiplier="65:71" id="JtP-wX-9v6"/>
-                                                            </constraints>
-                                                        </imageView>
-                                                        <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vw8-NU-Xdo" userLabel="Result View">
-                                                            <rect key="frame" x="12" y="16" width="0.0" height="85"/>
-                                                            <subviews>
-                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="rankingBox" translatesAutoresizingMaskIntoConstraints="NO" id="WXP-Jm-TE6">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="35" height="26"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="35" id="BaA-OK-29s"/>
-                                                                        <constraint firstAttribute="width" secondItem="WXP-Jm-TE6" secondAttribute="height" multiplier="35:26" id="M3p-6J-PDC"/>
-                                                                        <constraint firstAttribute="height" constant="26" id="ciI-nD-dvh"/>
-                                                                    </constraints>
-                                                                </imageView>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KMk-th-Wac">
-                                                                    <rect key="frame" x="17.5" y="3" width="0.0" height="0.0"/>
-                                                                    <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="10"/>
-                                                                    <color key="textColor" red="0.99607843137254903" green="0.99607843137254903" blue="0.99607843137254903" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QC8-vE-g7A">
-                                                                    <rect key="frame" x="0.0" y="36" width="0.0" height="0.0"/>
-                                                                    <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="24"/>
-                                                                    <color key="textColor" red="0.99607843139999996" green="0.99607843139999996" blue="0.99607843139999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LG2-Ty-rnA">
-                                                                    <rect key="frame" x="0.0" y="41" width="0.0" height="0.0"/>
-                                                                    <fontDescription key="fontDescription" name="Montserrat-SemiBold" family="Montserrat" pointSize="14"/>
-                                                                    <color key="textColor" red="0.99607843139999996" green="0.99607843139999996" blue="0.99607843139999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                </label>
-                                                            </subviews>
-                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <constraints>
-                                                                <constraint firstItem="QC8-vE-g7A" firstAttribute="width" secondItem="vw8-NU-Xdo" secondAttribute="width" multiplier="0.841667" id="03J-Po-QdH"/>
-                                                                <constraint firstItem="QC8-vE-g7A" firstAttribute="leading" secondItem="WXP-Jm-TE6" secondAttribute="leading" id="4dx-jd-rST"/>
-                                                                <constraint firstItem="WXP-Jm-TE6" firstAttribute="leading" secondItem="vw8-NU-Xdo" secondAttribute="leading" id="Gd1-AI-xd4"/>
-                                                                <constraint firstItem="KMk-th-Wac" firstAttribute="top" secondItem="WXP-Jm-TE6" secondAttribute="top" constant="3" id="Nhq-1x-5qi"/>
-                                                                <constraint firstItem="KMk-th-Wac" firstAttribute="centerX" secondItem="WXP-Jm-TE6" secondAttribute="centerX" id="Scn-S7-ip7"/>
-                                                                <constraint firstItem="QC8-vE-g7A" firstAttribute="top" secondItem="WXP-Jm-TE6" secondAttribute="bottom" constant="10" id="Wiq-3C-MTi"/>
-                                                                <constraint firstItem="WXP-Jm-TE6" firstAttribute="top" secondItem="vw8-NU-Xdo" secondAttribute="top" id="XmJ-a9-x5U"/>
-                                                                <constraint firstAttribute="height" constant="85" id="fvX-xc-WrL"/>
-                                                                <constraint firstItem="LG2-Ty-rnA" firstAttribute="leading" secondItem="QC8-vE-g7A" secondAttribute="leading" id="kJI-q7-9Uj"/>
-                                                                <constraint firstItem="LG2-Ty-rnA" firstAttribute="top" secondItem="QC8-vE-g7A" secondAttribute="bottom" constant="5" id="sY0-Ph-7cF"/>
-                                                            </constraints>
-                                                        </view>
-                                                    </subviews>
-                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                                    <constraints>
-                                                        <constraint firstItem="egU-Zk-Ngg" firstAttribute="centerX" secondItem="fkq-8O-qEk" secondAttribute="centerX" id="7i7-0u-b6z"/>
-                                                        <constraint firstAttribute="bottom" secondItem="0pu-gY-xby" secondAttribute="bottom" id="9gf-aQ-aKo"/>
-                                                        <constraint firstItem="0pu-gY-xby" firstAttribute="top" secondItem="fkq-8O-qEk" secondAttribute="top" id="QHW-Vb-odp"/>
-                                                        <constraint firstItem="IdT-mW-AiB" firstAttribute="centerY" secondItem="fkq-8O-qEk" secondAttribute="centerY" id="TFv-EC-8Z2"/>
-                                                        <constraint firstItem="egU-Zk-Ngg" firstAttribute="centerY" secondItem="fkq-8O-qEk" secondAttribute="centerY" id="THu-po-RHi"/>
-                                                        <constraint firstItem="0pu-gY-xby" firstAttribute="leading" secondItem="IdT-mW-AiB" secondAttribute="leading" id="WzX-G5-aUt"/>
-                                                        <constraint firstItem="vw8-NU-Xdo" firstAttribute="top" secondItem="IdT-mW-AiB" secondAttribute="top" constant="25.5" id="XJd-bL-NQZ"/>
-                                                        <constraint firstItem="IdT-mW-AiB" firstAttribute="centerX" secondItem="fkq-8O-qEk" secondAttribute="centerX" id="sV6-uu-PYI"/>
-                                                        <constraint firstItem="vw8-NU-Xdo" firstAttribute="leading" secondItem="IdT-mW-AiB" secondAttribute="leading" constant="21.5" id="zQx-kc-dZN"/>
-                                                    </constraints>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                            <integer key="value" value="10"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                        <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
-                                                    </userDefinedRuntimeAttributes>
-                                                </view>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstAttribute="bottom" secondItem="fkq-8O-qEk" secondAttribute="bottom" id="71J-NV-EAm"/>
-                                                <constraint firstItem="fkq-8O-qEk" firstAttribute="top" secondItem="yZE-qI-3Ft" secondAttribute="top" id="JON-8q-YHb"/>
-                                                <constraint firstItem="fkq-8O-qEk" firstAttribute="width" secondItem="yZE-qI-3Ft" secondAttribute="width" id="RRq-zB-LG7"/>
-                                                <constraint firstItem="fkq-8O-qEk" firstAttribute="leading" secondItem="yZE-qI-3Ft" secondAttribute="leading" id="WIh-y4-wlK"/>
-                                                <constraint firstAttribute="trailing" secondItem="fkq-8O-qEk" secondAttribute="trailing" id="bEO-eA-IRs"/>
-                                                <constraint firstItem="fkq-8O-qEk" firstAttribute="height" secondItem="yZE-qI-3Ft" secondAttribute="height" id="m7N-Cf-enc"/>
-                                            </constraints>
-                                            <userDefinedRuntimeAttributes>
-                                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                    <integer key="value" value="10"/>
-                                                </userDefinedRuntimeAttribute>
-                                                <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
-                                            </userDefinedRuntimeAttributes>
-                                        </collectionViewCellContentView>
-                                        <connections>
-                                            <outlet property="detailPhotoImageView" destination="IdT-mW-AiB" id="N3o-li-hYl"/>
-                                            <outlet property="diamondsImageView" destination="egU-Zk-Ngg" id="Vty-rA-HRv"/>
-                                            <outlet property="mainView" destination="fkq-8O-qEk" id="ji0-re-xBA"/>
-                                            <outlet property="percentLabel" destination="LG2-Ty-rnA" id="hHK-92-VYB"/>
-                                            <outlet property="pickedNumLabel" destination="QC8-vE-g7A" id="Clu-7C-fr5"/>
-                                            <outlet property="rankingLabel" destination="KMk-th-Wac" id="smc-sG-SFg"/>
-                                            <outlet property="resultColorView" destination="0pu-gY-xby" id="aKY-zF-xYE"/>
-                                            <outlet property="resultView" destination="vw8-NU-Xdo" id="GaM-SM-5xF"/>
-                                            <outlet property="viewWidthConstraint" destination="FU1-Zg-R3B" id="7Jt-O9-Xrb"/>
-                                        </connections>
-                                    </collectionViewCell>
-                                </cells>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="inset">
-                                        <integer key="value" value="44"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <outlet property="dataSource" destination="hjh-eJ-59M" id="xy3-rn-U4c"/>
-                                    <outlet property="delegate" destination="hjh-eJ-59M" id="ww0-jJ-Epk"/>
-                                </connections>
-                            </collectionView>
-                            <view hidden="YES" contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VvQ-sh-e3K">
-                                <rect key="frame" x="0.0" y="813" width="414" height="83"/>
-                                <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="u1i-50-UtO">
-                                        <rect key="frame" x="101.5" y="352" width="211.5" height="104"/>
-                                        <subviews>
-                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="trash" translatesAutoresizingMaskIntoConstraints="NO" id="EpZ-By-SfV">
-                                                <rect key="frame" x="0.0" y="0.0" width="211.5" height="48.5"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" secondItem="EpZ-By-SfV" secondAttribute="height" multiplier="211:48" id="0Ii-Qe-IwR"/>
-                                                </constraints>
-                                            </imageView>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="게시글이 삭제되어 볼 수 없어요. 홈으로 돌아가주세요." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="29Q-7Z-PQY">
-                                                <rect key="frame" x="0.0" y="56.5" width="211.5" height="47.5"/>
-                                                <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="16"/>
-                                                <color key="textColor" red="0.30196078431372547" green="0.30980392156862746" blue="0.32156862745098036" alpha="1" colorSpace="calibratedRGB"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                    </stackView>
-                                </subviews>
-                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <constraints>
-                                    <constraint firstItem="u1i-50-UtO" firstAttribute="centerX" secondItem="VvQ-sh-e3K" secondAttribute="centerX" id="abV-9e-eFb"/>
-                                    <constraint firstItem="u1i-50-UtO" firstAttribute="centerY" secondItem="VvQ-sh-e3K" secondAttribute="centerY" id="h4S-KN-15V"/>
-                                </constraints>
-                            </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nM7-Ii-Esh" userLabel="Feedback View">
                                 <rect key="frame" x="0.0" y="553" width="414" height="100"/>
                                 <subviews>
@@ -948,6 +729,225 @@
                                     <constraint firstItem="eFd-LK-A9A" firstAttribute="centerY" secondItem="nM7-Ii-Esh" secondAttribute="centerY" id="P0R-9U-MFY"/>
                                     <constraint firstItem="eFd-LK-A9A" firstAttribute="centerX" secondItem="nM7-Ii-Esh" secondAttribute="centerX" id="XkH-aT-JEC"/>
                                     <constraint firstAttribute="height" constant="100" id="lj2-Kn-ZpA"/>
+                                </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cEW-AT-Rkn" userLabel="Title View">
+                                <rect key="frame" x="20" y="184" width="374" height="45"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0/0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DLK-JD-wXx">
+                                        <rect key="frame" x="178" y="10" width="18.5" height="18"/>
+                                        <fontDescription key="fontDescription" name="NotoSansCJKkr-Regular" family="Noto Sans CJK KR" pointSize="12"/>
+                                        <color key="textColor" red="0.69803921570000005" green="0.70588235290000001" blue="0.71372549019999998" alpha="1" colorSpace="calibratedRGB"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mmd-Ur-e39">
+                                        <rect key="frame" x="16" y="33" width="342" height="0.0"/>
+                                        <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="16"/>
+                                        <color key="textColor" red="0.99607843139999996" green="0.99607843139999996" blue="0.99607843139999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" red="0.1019607843" green="0.10980392160000001" blue="0.1215686275" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                <constraints>
+                                    <constraint firstItem="DLK-JD-wXx" firstAttribute="top" secondItem="cEW-AT-Rkn" secondAttribute="top" constant="10" id="9zk-4P-fRW"/>
+                                    <constraint firstAttribute="bottom" secondItem="mmd-Ur-e39" secondAttribute="bottom" constant="12" id="BeJ-WD-xzd"/>
+                                    <constraint firstItem="DLK-JD-wXx" firstAttribute="centerX" secondItem="cEW-AT-Rkn" secondAttribute="centerX" id="H5M-u3-g58"/>
+                                    <constraint firstItem="mmd-Ur-e39" firstAttribute="top" secondItem="DLK-JD-wXx" secondAttribute="bottom" constant="5" id="klA-6k-PsH"/>
+                                    <constraint firstItem="mmd-Ur-e39" firstAttribute="centerX" secondItem="cEW-AT-Rkn" secondAttribute="centerX" id="ntZ-lf-tfb"/>
+                                    <constraint firstAttribute="trailing" secondItem="mmd-Ur-e39" secondAttribute="trailing" constant="16" id="yIe-Yj-dJ5"/>
+                                    <constraint firstItem="mmd-Ur-e39" firstAttribute="leading" secondItem="cEW-AT-Rkn" secondAttribute="leading" constant="16" id="ygp-jQ-12G"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="10"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="T04-YG-drm" customClass="ScalingCarouselView" customModule="ScalingCarousel">
+                                <rect key="frame" x="0.0" y="253" width="414" height="300"/>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="300" id="b0J-7e-IBB"/>
+                                    <constraint firstAttribute="height" relation="lessThanOrEqual" constant="300" id="rp1-lJ-EOI"/>
+                                </constraints>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="z8B-7L-A6z">
+                                    <size key="itemSize" width="280" height="280"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="VoteDetailCollectionViewCell" id="ryq-Kc-p5L" customClass="VoteDetailCollectionViewCell" customModule="Picme" customModuleProvider="target">
+                                        <rect key="frame" x="67" y="0.0" width="280" height="280"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="yZE-qI-3Ft">
+                                            <rect key="frame" x="0.0" y="0.0" width="280" height="280"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fkq-8O-qEk">
+                                                    <rect key="frame" x="0.0" y="0.0" width="280" height="280"/>
+                                                    <subviews>
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="IdT-mW-AiB">
+                                                            <rect key="frame" x="-9.5" y="-9.5" width="299" height="299"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="299" id="6bJ-cm-Q8W"/>
+                                                                <constraint firstAttribute="width" secondItem="IdT-mW-AiB" secondAttribute="height" multiplier="1:1" id="Xpt-Xc-Pcv"/>
+                                                            </constraints>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                    <integer key="value" value="10"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                            </userDefinedRuntimeAttributes>
+                                                        </imageView>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0pu-gY-xby">
+                                                            <rect key="frame" x="-9.5" y="0.0" width="0.0" height="280"/>
+                                                            <color key="backgroundColor" red="0.92156862745098034" green="0.41176470588235292" blue="0.6588235294117647" alpha="0.80000000000000004" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" id="FU1-Zg-R3B"/>
+                                                            </constraints>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                    <integer key="value" value="10"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                            </userDefinedRuntimeAttributes>
+                                                        </view>
+                                                        <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="diamonds" translatesAutoresizingMaskIntoConstraints="NO" id="egU-Zk-Ngg">
+                                                            <rect key="frame" x="107.5" y="104.5" width="65" height="71"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" secondItem="egU-Zk-Ngg" secondAttribute="height" multiplier="65:71" id="JtP-wX-9v6"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                        <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vw8-NU-Xdo" userLabel="Result View">
+                                                            <rect key="frame" x="12" y="16" width="0.0" height="85"/>
+                                                            <subviews>
+                                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="rankingBox" translatesAutoresizingMaskIntoConstraints="NO" id="WXP-Jm-TE6">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="35" height="26"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="35" id="BaA-OK-29s"/>
+                                                                        <constraint firstAttribute="width" secondItem="WXP-Jm-TE6" secondAttribute="height" multiplier="35:26" id="M3p-6J-PDC"/>
+                                                                        <constraint firstAttribute="height" constant="26" id="ciI-nD-dvh"/>
+                                                                    </constraints>
+                                                                </imageView>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KMk-th-Wac">
+                                                                    <rect key="frame" x="17.5" y="3" width="0.0" height="0.0"/>
+                                                                    <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="10"/>
+                                                                    <color key="textColor" red="0.99607843137254903" green="0.99607843137254903" blue="0.99607843137254903" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QC8-vE-g7A">
+                                                                    <rect key="frame" x="0.0" y="36" width="0.0" height="0.0"/>
+                                                                    <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="24"/>
+                                                                    <color key="textColor" red="0.99607843139999996" green="0.99607843139999996" blue="0.99607843139999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LG2-Ty-rnA">
+                                                                    <rect key="frame" x="0.0" y="41" width="0.0" height="0.0"/>
+                                                                    <fontDescription key="fontDescription" name="Montserrat-SemiBold" family="Montserrat" pointSize="14"/>
+                                                                    <color key="textColor" red="0.99607843139999996" green="0.99607843139999996" blue="0.99607843139999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                                    <nil key="highlightedColor"/>
+                                                                </label>
+                                                            </subviews>
+                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <constraints>
+                                                                <constraint firstItem="QC8-vE-g7A" firstAttribute="width" secondItem="vw8-NU-Xdo" secondAttribute="width" multiplier="0.841667" id="03J-Po-QdH"/>
+                                                                <constraint firstItem="QC8-vE-g7A" firstAttribute="leading" secondItem="WXP-Jm-TE6" secondAttribute="leading" id="4dx-jd-rST"/>
+                                                                <constraint firstItem="WXP-Jm-TE6" firstAttribute="leading" secondItem="vw8-NU-Xdo" secondAttribute="leading" id="Gd1-AI-xd4"/>
+                                                                <constraint firstItem="KMk-th-Wac" firstAttribute="top" secondItem="WXP-Jm-TE6" secondAttribute="top" constant="3" id="Nhq-1x-5qi"/>
+                                                                <constraint firstItem="KMk-th-Wac" firstAttribute="centerX" secondItem="WXP-Jm-TE6" secondAttribute="centerX" id="Scn-S7-ip7"/>
+                                                                <constraint firstItem="QC8-vE-g7A" firstAttribute="top" secondItem="WXP-Jm-TE6" secondAttribute="bottom" constant="10" id="Wiq-3C-MTi"/>
+                                                                <constraint firstItem="WXP-Jm-TE6" firstAttribute="top" secondItem="vw8-NU-Xdo" secondAttribute="top" id="XmJ-a9-x5U"/>
+                                                                <constraint firstAttribute="height" constant="85" id="fvX-xc-WrL"/>
+                                                                <constraint firstItem="LG2-Ty-rnA" firstAttribute="leading" secondItem="QC8-vE-g7A" secondAttribute="leading" id="kJI-q7-9Uj"/>
+                                                                <constraint firstItem="LG2-Ty-rnA" firstAttribute="top" secondItem="QC8-vE-g7A" secondAttribute="bottom" constant="5" id="sY0-Ph-7cF"/>
+                                                            </constraints>
+                                                        </view>
+                                                    </subviews>
+                                                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                    <constraints>
+                                                        <constraint firstItem="egU-Zk-Ngg" firstAttribute="centerX" secondItem="fkq-8O-qEk" secondAttribute="centerX" id="7i7-0u-b6z"/>
+                                                        <constraint firstAttribute="bottom" secondItem="0pu-gY-xby" secondAttribute="bottom" id="9gf-aQ-aKo"/>
+                                                        <constraint firstItem="0pu-gY-xby" firstAttribute="top" secondItem="fkq-8O-qEk" secondAttribute="top" id="QHW-Vb-odp"/>
+                                                        <constraint firstItem="IdT-mW-AiB" firstAttribute="centerY" secondItem="fkq-8O-qEk" secondAttribute="centerY" id="TFv-EC-8Z2"/>
+                                                        <constraint firstItem="egU-Zk-Ngg" firstAttribute="centerY" secondItem="fkq-8O-qEk" secondAttribute="centerY" id="THu-po-RHi"/>
+                                                        <constraint firstItem="0pu-gY-xby" firstAttribute="leading" secondItem="IdT-mW-AiB" secondAttribute="leading" id="WzX-G5-aUt"/>
+                                                        <constraint firstItem="vw8-NU-Xdo" firstAttribute="top" secondItem="IdT-mW-AiB" secondAttribute="top" constant="25.5" id="XJd-bL-NQZ"/>
+                                                        <constraint firstItem="IdT-mW-AiB" firstAttribute="centerX" secondItem="fkq-8O-qEk" secondAttribute="centerX" id="sV6-uu-PYI"/>
+                                                        <constraint firstItem="vw8-NU-Xdo" firstAttribute="leading" secondItem="IdT-mW-AiB" secondAttribute="leading" constant="21.5" id="zQx-kc-dZN"/>
+                                                    </constraints>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                            <integer key="value" value="10"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                                    </userDefinedRuntimeAttributes>
+                                                </view>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="fkq-8O-qEk" secondAttribute="bottom" id="71J-NV-EAm"/>
+                                                <constraint firstItem="fkq-8O-qEk" firstAttribute="top" secondItem="yZE-qI-3Ft" secondAttribute="top" id="JON-8q-YHb"/>
+                                                <constraint firstItem="fkq-8O-qEk" firstAttribute="width" secondItem="yZE-qI-3Ft" secondAttribute="width" id="RRq-zB-LG7"/>
+                                                <constraint firstItem="fkq-8O-qEk" firstAttribute="leading" secondItem="yZE-qI-3Ft" secondAttribute="leading" id="WIh-y4-wlK"/>
+                                                <constraint firstAttribute="trailing" secondItem="fkq-8O-qEk" secondAttribute="trailing" id="bEO-eA-IRs"/>
+                                                <constraint firstItem="fkq-8O-qEk" firstAttribute="height" secondItem="yZE-qI-3Ft" secondAttribute="height" id="m7N-Cf-enc"/>
+                                            </constraints>
+                                            <userDefinedRuntimeAttributes>
+                                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                    <integer key="value" value="10"/>
+                                                </userDefinedRuntimeAttribute>
+                                                <userDefinedRuntimeAttribute type="boolean" keyPath="layer.masksToBounds" value="YES"/>
+                                            </userDefinedRuntimeAttributes>
+                                        </collectionViewCellContentView>
+                                        <connections>
+                                            <outlet property="detailPhotoImageView" destination="IdT-mW-AiB" id="N3o-li-hYl"/>
+                                            <outlet property="diamondsImageView" destination="egU-Zk-Ngg" id="Vty-rA-HRv"/>
+                                            <outlet property="mainView" destination="fkq-8O-qEk" id="ji0-re-xBA"/>
+                                            <outlet property="percentLabel" destination="LG2-Ty-rnA" id="hHK-92-VYB"/>
+                                            <outlet property="pickedNumLabel" destination="QC8-vE-g7A" id="Clu-7C-fr5"/>
+                                            <outlet property="rankingLabel" destination="KMk-th-Wac" id="smc-sG-SFg"/>
+                                            <outlet property="resultColorView" destination="0pu-gY-xby" id="aKY-zF-xYE"/>
+                                            <outlet property="resultView" destination="vw8-NU-Xdo" id="GaM-SM-5xF"/>
+                                            <outlet property="viewWidthConstraint" destination="FU1-Zg-R3B" id="7Jt-O9-Xrb"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                </cells>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="inset">
+                                        <integer key="value" value="44"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <outlet property="dataSource" destination="hjh-eJ-59M" id="xy3-rn-U4c"/>
+                                    <outlet property="delegate" destination="hjh-eJ-59M" id="ww0-jJ-Epk"/>
+                                </connections>
+                            </collectionView>
+                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VvQ-sh-e3K">
+                                <rect key="frame" x="0.0" y="88" width="414" height="808"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="u1i-50-UtO">
+                                        <rect key="frame" x="101.5" y="352" width="211.5" height="104"/>
+                                        <subviews>
+                                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="trash" translatesAutoresizingMaskIntoConstraints="NO" id="EpZ-By-SfV">
+                                                <rect key="frame" x="0.0" y="0.0" width="211.5" height="48.5"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" secondItem="EpZ-By-SfV" secondAttribute="height" multiplier="211:48" id="0Ii-Qe-IwR"/>
+                                                </constraints>
+                                            </imageView>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="게시글이 삭제되어 볼 수 없어요. 홈으로 돌아가주세요." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="29Q-7Z-PQY">
+                                                <rect key="frame" x="0.0" y="56.5" width="211.5" height="47.5"/>
+                                                <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="16"/>
+                                                <color key="textColor" red="0.30196078431372547" green="0.30980392156862746" blue="0.32156862745098036" alpha="1" colorSpace="calibratedRGB"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                    </stackView>
+                                </subviews>
+                                <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="u1i-50-UtO" firstAttribute="centerX" secondItem="VvQ-sh-e3K" secondAttribute="centerX" id="abV-9e-eFb"/>
+                                    <constraint firstItem="u1i-50-UtO" firstAttribute="centerY" secondItem="VvQ-sh-e3K" secondAttribute="centerY" id="h4S-KN-15V"/>
                                 </constraints>
                             </view>
                         </subviews>

--- a/Picme/Picme/View/Storyboard/Main/Main.storyboard
+++ b/Picme/Picme/View/Storyboard/Main/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="zxu-2c-T0e">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
@@ -35,19 +35,19 @@
             <objects>
                 <viewController storyboardIdentifier="MainViewController" id="Y6W-OH-hqX" customClass="MainViewController" customModule="Picme" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="bYY-Zm-ohL">
-                                <rect key="frame" x="0.0" y="44" width="375" height="574"/>
+                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="sectionIndexBackgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MainTableViewCell" rowHeight="300" id="rNT-EV-ccY" customClass="MainTableViewCell" customModule="Picme" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="24.5" width="375" height="300"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="414" height="300"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="rNT-EV-ccY" id="yYn-pn-djr">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="300"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="300"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="1" translatesAutoresizingMaskIntoConstraints="NO" id="Mvv-OA-9oz">
@@ -58,14 +58,14 @@
                                                         <constraint firstAttribute="width" constant="40" id="nmB-GI-JtV"/>
                                                     </constraints>
                                                 </imageView>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y1l-K0-83N">
-                                                    <rect key="frame" x="20" y="64" width="30.5" height="23"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="y1l-K0-83N">
+                                                    <rect key="frame" x="20" y="64" width="0.0" height="23"/>
                                                     <fontDescription key="fontDescription" name="NotoSansCJKkr-Medium" family="Noto Sans CJK KR" pointSize="14"/>
                                                     <color key="textColor" red="0.99607843137254903" green="0.99607843137254903" blue="0.99607843137254903" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="ltH-kV-oc5">
-                                                    <rect key="frame" x="0.0" y="97" width="375" height="183"/>
+                                                    <rect key="frame" x="0.0" y="97" width="414" height="183"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="183" id="QOa-23-YuG"/>
                                                     </constraints>
@@ -132,16 +132,16 @@
                                                     </cells>
                                                 </collectionView>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="liA-ma-dUg" userLabel="Nickname Stack View">
-                                                    <rect key="frame" x="68" y="9.5" width="79.5" height="45"/>
+                                                    <rect key="frame" x="68" y="-19.5" width="69.5" height="103"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Nickname" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q1y-5r-kAt">
-                                                            <rect key="frame" x="0.0" y="0.0" width="79.5" height="24"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="q1y-5r-kAt">
+                                                            <rect key="frame" x="0.0" y="0.0" width="69.5" height="50"/>
                                                             <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="16"/>
                                                             <color key="textColor" red="0.90196078431372551" green="0.90588235294117647" blue="0.9137254901960784" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Participants" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HXw-Dx-nAU">
-                                                            <rect key="frame" x="0.0" y="27" width="79.5" height="18"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HXw-Dx-nAU">
+                                                            <rect key="frame" x="0.0" y="53" width="69.5" height="50"/>
                                                             <fontDescription key="fontDescription" name="NotoSansCJKkr-Medium" family="Noto Sans CJK KR" pointSize="12"/>
                                                             <color key="textColor" red="0.47058823529411764" green="0.4823529411764706" blue="0.50196078431372548" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
@@ -149,7 +149,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zZa-z8-hjs">
-                                                    <rect key="frame" x="265" y="20" width="90" height="24"/>
+                                                    <rect key="frame" x="304" y="20" width="90" height="24"/>
                                                     <subviews>
                                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="5.2999999999999998" translatesAutoresizingMaskIntoConstraints="NO" id="a8H-fO-XRM" userLabel="Timer Stack View">
                                                             <rect key="frame" x="9" y="3.5" width="72" height="16"/>
@@ -223,7 +223,7 @@
                                 <rect key="frame" x="0.0" y="409" width="414" height="404"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="hmm" translatesAutoresizingMaskIntoConstraints="NO" id="7fd-ST-BGc">
-                                        <rect key="frame" x="163.5" y="208" width="48" height="48"/>
+                                        <rect key="frame" x="183" y="208" width="48" height="48"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="7fd-ST-BGc" secondAttribute="height" multiplier="1:1" id="K8D-k0-Y7c"/>
                                             <constraint firstAttribute="height" constant="48" id="Pmr-TE-put"/>
@@ -231,7 +231,7 @@
                                         </constraints>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xPI-cZ-8Bp">
-                                        <rect key="frame" x="118" y="340" width="139" height="44"/>
+                                        <rect key="frame" x="137.5" y="340" width="139" height="44"/>
                                         <color key="backgroundColor" red="0.92156862745098034" green="0.28627450980392155" blue="0.60392156862745094" alpha="1" colorSpace="calibratedRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="EPj-Iz-Wtb"/>
@@ -252,7 +252,7 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="아직 투표가 없네요! 작성자님이 첫 번째 투표를 만들어주세요." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VZ5-1D-wwc">
-                                        <rect key="frame" x="36" y="264" width="303" height="48"/>
+                                        <rect key="frame" x="55.5" y="264" width="303" height="48"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="303" id="45q-H3-aDu"/>
                                             <constraint firstAttribute="height" constant="48" id="5sa-FP-MI2"/>
@@ -274,7 +274,7 @@
                                 </constraints>
                             </view>
                             <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nJX-5u-sb8">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                                 <color key="barTintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <textAttributes key="titleTextAttributes">
                                     <color key="textColor" red="0.99607843137254903" green="0.99607843137254903" blue="0.99607843137254903" alpha="1" colorSpace="calibratedRGB"/>
@@ -286,7 +286,7 @@
                                 </items>
                             </navigationBar>
                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pGo-Kk-fLs">
-                                <rect key="frame" x="14.5" y="0.0" width="157.5" height="44"/>
+                                <rect key="frame" x="14.5" y="44" width="157.5" height="44"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="인생샷" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qge-TD-kVp">
                                         <rect key="frame" x="0.0" y="0.0" width="44.5" height="44"/>
@@ -342,11 +342,11 @@
             <objects>
                 <viewController storyboardIdentifier="VoteDetailViewController" id="hjh-eJ-59M" customClass="VoteDetailViewController" customModule="Picme" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="idd-lq-4rt">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4oQ-Hg-wQt">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="cwl-u6-KLO"/>
                                 </constraints>
@@ -366,7 +366,7 @@
                                 </items>
                             </navigationBar>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="1" translatesAutoresizingMaskIntoConstraints="NO" id="Lge-DT-c9U">
-                                <rect key="frame" x="20" y="68" width="40" height="40"/>
+                                <rect key="frame" x="20" y="112" width="40" height="40"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="OlV-F4-J6X"/>
                                     <constraint firstAttribute="width" constant="40" id="VaX-vx-GmT"/>
@@ -374,16 +374,16 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="Khk-tx-YN4" userLabel="Nickname Stack View">
-                                <rect key="frame" x="68" y="65.5" width="81" height="45"/>
+                                <rect key="frame" x="68" y="80.5" width="81" height="103"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Nickname" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xcI-fx-oFf">
-                                        <rect key="frame" x="0.0" y="0.0" width="81" height="21"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xcI-fx-oFf">
+                                        <rect key="frame" x="0.0" y="0.0" width="81" height="50"/>
                                         <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="14"/>
                                         <color key="textColor" red="0.90196078430000004" green="0.90588235289999997" blue="0.91372549020000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Participants" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ltx-EX-QXk">
-                                        <rect key="frame" x="0.0" y="24" width="81" height="21"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ltx-EX-QXk">
+                                        <rect key="frame" x="0.0" y="53" width="81" height="50"/>
                                         <fontDescription key="fontDescription" name="NotoSansCJKkr-Medium" family="Noto Sans CJK KR" pointSize="14"/>
                                         <color key="textColor" red="0.47058823529999999" green="0.4823529412" blue="0.50196078430000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <nil key="highlightedColor"/>
@@ -391,7 +391,7 @@
                                 </subviews>
                             </stackView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vTV-am-Nmy" userLabel="Timer View">
-                                <rect key="frame" x="265.5" y="68" width="89.5" height="24"/>
+                                <rect key="frame" x="304.5" y="112" width="89.5" height="24"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="Pqd-QZ-YWN" userLabel="Timer Stack View">
                                         <rect key="frame" x="9" y="3.5" width="71.5" height="16"/>
@@ -431,10 +431,10 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Lbn-9o-aCP" userLabel="Pick View">
-                                <rect key="frame" x="0.0" y="556.5" width="375" height="87.5"/>
+                                <rect key="frame" x="0.0" y="553" width="414" height="87.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="otq-hq-BSA">
-                                        <rect key="frame" x="150" y="43.5" width="75" height="44"/>
+                                        <rect key="frame" x="169.5" y="43.5" width="75" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="44" id="FSm-fD-UL3"/>
                                             <constraint firstAttribute="width" constant="75" id="lXb-W3-6BR"/>
@@ -454,7 +454,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </button>
                                     <pageControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="6" translatesAutoresizingMaskIntoConstraints="NO" id="1hK-7q-nex">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="27.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="27.5"/>
                                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <color key="pageIndicatorTintColor" red="0.2156862745" green="0.23529411759999999" blue="0.25882352939999997" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <color key="currentPageIndicatorTintColor" red="0.69803921570000005" green="0.70588235290000001" blue="0.71372549019999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
@@ -471,22 +471,16 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cEW-AT-Rkn" userLabel="Title View">
-                                <rect key="frame" x="20" y="140" width="335" height="92.5"/>
+                                <rect key="frame" x="20" y="184" width="374" height="45"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="currentPage/totalPage" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DLK-JD-wXx">
-                                        <rect key="frame" x="104.5" y="10" width="126" height="18"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="18" id="V5k-Vc-U0R"/>
-                                        </constraints>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0/0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DLK-JD-wXx">
+                                        <rect key="frame" x="178" y="10" width="18.5" height="18"/>
                                         <fontDescription key="fontDescription" name="NotoSansCJKkr-Regular" family="Noto Sans CJK KR" pointSize="12"/>
                                         <color key="textColor" red="0.69803921570000005" green="0.70588235290000001" blue="0.71372549019999998" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="사진 잘나온 거 한 장만 골라주세요! 최대 공백 포함 45자까지 제한이 걸려있어요!" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mmd-Ur-e39">
-                                        <rect key="frame" x="16" y="33" width="303" height="47.5"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" relation="lessThanOrEqual" constant="47.5" id="lyy-xM-GYY"/>
-                                        </constraints>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mmd-Ur-e39">
+                                        <rect key="frame" x="16" y="33" width="342" height="0.0"/>
                                         <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="16"/>
                                         <color key="textColor" red="0.99607843139999996" green="0.99607843139999996" blue="0.99607843139999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
@@ -497,7 +491,6 @@
                                     <constraint firstItem="DLK-JD-wXx" firstAttribute="top" secondItem="cEW-AT-Rkn" secondAttribute="top" constant="10" id="9zk-4P-fRW"/>
                                     <constraint firstAttribute="bottom" secondItem="mmd-Ur-e39" secondAttribute="bottom" constant="12" id="BeJ-WD-xzd"/>
                                     <constraint firstItem="DLK-JD-wXx" firstAttribute="centerX" secondItem="cEW-AT-Rkn" secondAttribute="centerX" id="H5M-u3-g58"/>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="72" id="ewu-Kl-UfS"/>
                                     <constraint firstItem="mmd-Ur-e39" firstAttribute="top" secondItem="DLK-JD-wXx" secondAttribute="bottom" constant="5" id="klA-6k-PsH"/>
                                     <constraint firstItem="mmd-Ur-e39" firstAttribute="centerX" secondItem="cEW-AT-Rkn" secondAttribute="centerX" id="ntZ-lf-tfb"/>
                                     <constraint firstAttribute="trailing" secondItem="mmd-Ur-e39" secondAttribute="trailing" constant="16" id="yIe-Yj-dJ5"/>
@@ -511,7 +504,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="T04-YG-drm" customClass="ScalingCarouselView" customModule="ScalingCarousel">
-                                <rect key="frame" x="0.0" y="256.5" width="375" height="300"/>
+                                <rect key="frame" x="0.0" y="253" width="414" height="300"/>
                                 <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="300" id="b0J-7e-IBB"/>
@@ -525,7 +518,7 @@
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="VoteDetailCollectionViewCell" id="ryq-Kc-p5L" customClass="VoteDetailCollectionViewCell" customModule="Picme" customModuleProvider="target">
-                                        <rect key="frame" x="47.5" y="0.0" width="280" height="280"/>
+                                        <rect key="frame" x="67" y="0.0" width="280" height="280"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="yZE-qI-3Ft">
                                             <rect key="frame" x="0.0" y="0.0" width="280" height="280"/>
@@ -567,7 +560,7 @@
                                                             </constraints>
                                                         </imageView>
                                                         <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vw8-NU-Xdo" userLabel="Result View">
-                                                            <rect key="frame" x="12" y="16" width="60" height="85"/>
+                                                            <rect key="frame" x="12" y="16" width="0.0" height="85"/>
                                                             <subviews>
                                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="rankingBox" translatesAutoresizingMaskIntoConstraints="NO" id="WXP-Jm-TE6">
                                                                     <rect key="frame" x="0.0" y="0.0" width="35" height="26"/>
@@ -577,20 +570,20 @@
                                                                         <constraint firstAttribute="height" constant="26" id="ciI-nD-dvh"/>
                                                                     </constraints>
                                                                 </imageView>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1위" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KMk-th-Wac">
-                                                                    <rect key="frame" x="10" y="3" width="15.5" height="15"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KMk-th-Wac">
+                                                                    <rect key="frame" x="17.5" y="3" width="0.0" height="0.0"/>
                                                                     <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="10"/>
                                                                     <color key="textColor" red="0.99607843137254903" green="0.99607843137254903" blue="0.99607843137254903" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="73명" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QC8-vE-g7A">
-                                                                    <rect key="frame" x="0.0" y="36" width="50.5" height="36"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QC8-vE-g7A">
+                                                                    <rect key="frame" x="0.0" y="36" width="0.0" height="0.0"/>
                                                                     <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="24"/>
                                                                     <color key="textColor" red="0.99607843139999996" green="0.99607843139999996" blue="0.99607843139999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="72.7%" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LG2-Ty-rnA">
-                                                                    <rect key="frame" x="0.0" y="77" width="41" height="17.5"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LG2-Ty-rnA">
+                                                                    <rect key="frame" x="0.0" y="41" width="0.0" height="0.0"/>
                                                                     <fontDescription key="fontDescription" name="Montserrat-SemiBold" family="Montserrat" pointSize="14"/>
                                                                     <color key="textColor" red="0.99607843139999996" green="0.99607843139999996" blue="0.99607843139999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                                     <nil key="highlightedColor"/>
@@ -673,7 +666,7 @@
                                 <rect key="frame" x="0.0" y="813" width="414" height="83"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="u1i-50-UtO">
-                                        <rect key="frame" x="82" y="259.5" width="211.5" height="104"/>
+                                        <rect key="frame" x="101.5" y="352" width="211.5" height="104"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="trash" translatesAutoresizingMaskIntoConstraints="NO" id="EpZ-By-SfV">
                                                 <rect key="frame" x="0.0" y="0.0" width="211.5" height="48.5"/>
@@ -697,10 +690,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nM7-Ii-Esh" userLabel="Feedback View">
-                                <rect key="frame" x="0.0" y="556.5" width="375" height="100"/>
+                                <rect key="frame" x="0.0" y="553" width="414" height="100"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="eFd-LK-A9A" userLabel="Feedback Stack View">
-                                        <rect key="frame" x="47.5" y="16.5" width="280" height="67"/>
+                                        <rect key="frame" x="67" y="16.5" width="280" height="67"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="U2j-ma-Wal" userLabel="Sensitivity Stack View">
                                                 <rect key="frame" x="0.0" y="0.0" width="48" height="67"/>

--- a/Picme/Picme/View/Storyboard/MyPage/MyPage.storyboard
+++ b/Picme/Picme/View/Storyboard/MyPage/MyPage.storyboard
@@ -122,8 +122,8 @@
                                             <constraint firstAttribute="width" constant="44" id="bSk-eQ-UDU"/>
                                         </constraints>
                                     </imageView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Nickname" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DeA-JF-XBH">
-                                        <rect key="frame" x="71" y="35.5" width="69.5" height="21"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DeA-JF-XBH">
+                                        <rect key="frame" x="71" y="46" width="0.0" height="0.0"/>
                                         <fontDescription key="fontDescription" name="NotoSansCJKkr-Bold" family="Noto Sans CJK KR" pointSize="14"/>
                                         <color key="textColor" red="0.90196078431372551" green="0.90588235294117647" blue="0.9137254901960784" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>

--- a/Picme/Picme/ViewModel/Main/MainViewModel.swift
+++ b/Picme/Picme/ViewModel/Main/MainViewModel.swift
@@ -36,7 +36,11 @@ class MainViewModel {
     }
     
     var totalCount: Int {
-        return total
+        get {
+            return total
+        } set(value) {
+            total = value
+        }
     }
     
     var currentCount: Int {

--- a/Picme/Picme/ViewModel/VoteDetail/VoteDetailViewModel.swift
+++ b/Picme/Picme/ViewModel/VoteDetail/VoteDetailViewModel.swift
@@ -25,7 +25,7 @@ final class VoteDetailViewModel {
     
     // MARK: - 게시글 조회
     
-    func fetchVoteDetail(postId: String) {
+    func fetchVoteDetail(postId: String, completion: @escaping (String) -> Void ) {
         guard let service = service else {
             onErrorHandling?(APIError.networkFailed)
             return
@@ -46,6 +46,7 @@ final class VoteDetailViewModel {
                     print("serverERR")
                 case .networkFail:
                     print("networkERR")
+                    completion("networkERR")
                 }
             }
         }


### PR DESCRIPTION
### 투표 상세 화면
- 페이지 컨트롤 인덱스 1부터 시작되도록 수정
- 투표 삭제 뷰 UI 수정
- 투표 삭제할 경우 로직 수정
- pick view에서 선택된 이미지 다시 클릭하면 비활성화 되도록 변경
- 마감된 투표에서 투표 안한 사용자의 경우 원픽 버튼 이동 금지

### 메인 화면
- 투표 상세에서 투표 삭제후 돌아오면 테이블뷰에서 삭제되도록 Notification Center 구현 

#### 전체적으로 주석 추가 및 제거